### PR TITLE
Fix: Update dependency to resolve npm audit vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "command-line-usage": "^6.1.3",
                 "es-main": "^1.3.0",
                 "eslint": "^8.38.0",
-                "eslint-plugin-ember": "^11.4.8",
+                "eslint-plugin-ember": "^12.7.5",
                 "eslint-plugin-react": "^7.32.2",
                 "eslint-plugin-vue": "^9.10.0",
                 "expect.js": "^0.3.1",
@@ -554,89 +554,73 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
-        "node_modules/@glimmer/env": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/@glimmer/env/-/env-0.1.7.tgz",
-            "integrity": "sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@glimmer/global-context": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.84.3.tgz",
-            "integrity": "sha512-8Oy9Wg5IZxMEeAnVmzD2NkObf89BeHoFSzJgJROE/deutd3rxg83mvlOez4zBBGYwnTb+VGU2LYRpet92egJjA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@glimmer/env": "^0.1.7"
-            }
-        },
         "node_modules/@glimmer/interfaces": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.84.3.tgz",
-            "integrity": "sha512-dk32ykoNojt0mvEaIW6Vli5MGTbQo58uy3Epj7ahCgTHmWOKuw/0G83f2UmFprRwFx689YTXG38I/vbpltEjzg==",
+            "version": "0.94.6",
+            "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+            "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@simple-dom/interface": "^1.4.0"
+                "@simple-dom/interface": "^1.4.0",
+                "type-fest": "^4.35.0"
             }
         },
-        "node_modules/@glimmer/reference": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.84.3.tgz",
-            "integrity": "sha512-lV+p/aWPVC8vUjmlvYVU7WQJsLh319SdXuAWoX/SE3pq340BJlAJiEcAc6q52y9JNhT57gMwtjMX96W5Xcx/qw==",
+        "node_modules/@glimmer/interfaces/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@glimmer/env": "^0.1.7",
-                "@glimmer/global-context": "0.84.3",
-                "@glimmer/interfaces": "0.84.3",
-                "@glimmer/util": "0.84.3",
-                "@glimmer/validator": "0.84.3"
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@glimmer/syntax": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.84.3.tgz",
-            "integrity": "sha512-ioVbTic6ZisLxqTgRBL2PCjYZTFIwobifCustrozRU2xGDiYvVIL0vt25h2c1ioDsX59UgVlDkIK4YTAQQSd2A==",
+            "version": "0.95.0",
+            "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.95.0.tgz",
+            "integrity": "sha512-W/PHdODnpONsXjbbdY9nedgIHpglMfOzncf/moLVrKIcCfeQhw2vG07Rs/YW8KeJCgJRCLkQsi+Ix7XvrurGAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@glimmer/interfaces": "0.84.3",
-                "@glimmer/util": "0.84.3",
-                "@handlebars/parser": "~2.0.0",
+                "@glimmer/interfaces": "0.94.6",
+                "@glimmer/util": "0.94.8",
+                "@glimmer/wire-format": "0.94.8",
+                "@handlebars/parser": "~2.2.0",
                 "simple-html-tokenizer": "^0.5.11"
             }
         },
         "node_modules/@glimmer/util": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.84.3.tgz",
-            "integrity": "sha512-qFkh6s16ZSRuu2rfz3T4Wp0fylFj3HBsONGXQcrAdZjdUaIS6v3pNj6mecJ71qRgcym9Hbaq/7/fefIwECUiKw==",
+            "version": "0.94.8",
+            "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.94.8.tgz",
+            "integrity": "sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@glimmer/env": "0.1.7",
-                "@glimmer/interfaces": "0.84.3",
-                "@simple-dom/interface": "^1.4.0"
+                "@glimmer/interfaces": "0.94.6"
             }
         },
-        "node_modules/@glimmer/validator": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.84.3.tgz",
-            "integrity": "sha512-RTBV4TokUB0vI31UC7ikpV7lOYpWUlyqaKV//pRC4pexYMlmqnVhkFrdiimB/R1XyNdUOQUmnIAcdic39NkbhQ==",
+        "node_modules/@glimmer/wire-format": {
+            "version": "0.94.8",
+            "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.94.8.tgz",
+            "integrity": "sha512-A+Cp5m6vZMAEu0Kg/YwU2dJZXyYxVJs2zI57d3CP6NctmX7FsT8WjViiRUmt5abVmMmRH5b8BUovqY6GSMAdrw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@glimmer/env": "^0.1.7",
-                "@glimmer/global-context": "0.84.3"
+                "@glimmer/interfaces": "0.94.6"
             }
         },
         "node_modules/@handlebars/parser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@handlebars/parser/-/parser-2.0.0.tgz",
-            "integrity": "sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@handlebars/parser/-/parser-2.2.2.tgz",
+            "integrity": "sha512-n/SZW+12rwikx/f8YcSv9JCi5p9vn1Bnts9ZtVvfErG4h0gbjHI1H1ZMhVUnaOC7yzFc6PtsCKIK8XeTnL90Gw==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "engines": {
+                "node": "^18 || ^20 || ^22 || >=24"
+            }
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.13.0",
@@ -1101,13 +1085,6 @@
             "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
             "license": "MIT"
         },
-        "node_modules/@types/minimatch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/node": {
             "version": "24.9.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
@@ -1143,13 +1120,6 @@
             "version": "7.7.1",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
             "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/symlink-or-copy": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@types/symlink-or-copy/-/symlink-or-copy-1.2.2.tgz",
-            "integrity": "sha512-MQ1AnmTLOncwEf9IVU+B2e4Hchrku5N67NkgcAHW0p3sdzPe0FNMANxEm6OJUzPniEQGkeT3OROLlCwZJLWFZA==",
             "dev": true,
             "license": "MIT"
         },
@@ -1245,6 +1215,23 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.50.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.0.tgz",
+            "integrity": "sha512-vxd3G/ybKTSlm31MOA96gqvrRGv9RJ7LGtZCn2Vrc5htA0zCDvcMqUkifcjrWNNKXHUU3WCkYOzzVSFBd0wa2w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
@@ -1579,16 +1566,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/array-equal": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.2.tgz",
-            "integrity": "sha512-gUHx76KtnhEgB3HOuFYiCm3FIdEs6ocM2asHvNTkfu/Y09qQVrrVVaOKENmS2KkSaGoxgXNqC+ZVtR/n0MOkSA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/array-includes": {
             "version": "3.1.9",
             "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
@@ -1720,59 +1697,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/async": {
-            "version": "2.6.4",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-            "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lodash": "^4.17.14"
-            }
-        },
-        "node_modules/async-disk-cache": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
-            "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^2.1.3",
-                "heimdalljs": "^0.2.3",
-                "istextorbinary": "2.1.0",
-                "mkdirp": "^0.5.0",
-                "rimraf": "^2.5.3",
-                "rsvp": "^3.0.18",
-                "username-sync": "^1.0.2"
-            }
-        },
-        "node_modules/async-disk-cache/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/async-disk-cache/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/async-disk-cache/node_modules/rsvp": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "0.12.* || 4.* || 6.* || >= 7.*"
-            }
-        },
         "node_modules/async-function": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -1782,34 +1706,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/async-promise-queue": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.5.tgz",
-            "integrity": "sha512-xi0aQ1rrjPWYmqbwr18rrSKbSaXIeIwSd1J4KAgVfkq8utNbdZoht7GfvfY6swFUAMJ9obkc4WPJmtGwl+B8dw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "async": "^2.4.1",
-                "debug": "^2.6.8"
-            }
-        },
-        "node_modules/async-promise-queue/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/async-promise-queue/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -1833,42 +1729,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/babel-import-util": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-0.2.0.tgz",
-            "integrity": "sha512-CtWYYHU/MgK88rxMrLfkD356dApswtR/kWZ/c6JifG1m10e7tBBrs/366dFzWMAoqYmG5/JSh+94tUSpIwh+ag==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 12.*"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
             "license": "MIT"
         },
         "node_modules/basic-auth": {
@@ -1911,38 +1776,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/binaryextensions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
-            "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8"
-            },
-            "funding": {
-                "url": "https://bevry.me/fund"
-            }
-        },
-        "node_modules/bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
-        "node_modules/blank-object": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
-            "integrity": "sha512-kXQ19Xhoghiyw66CUiGypnuRpWlbHAzY/+NyvqTEdTfhfQGH1/dbEMYiXju7fYKIFePpzp/y9dsu5Cu/PkmawQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1972,254 +1805,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/broccoli-debug": {
-            "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.5.tgz",
-            "integrity": "sha512-RIVjHvNar9EMCLDW/FggxFRXqpjhncM/3qq87bn/y+/zR9tqEkHvTqbyOc4QnB97NO2m6342w4wGkemkaeOuWg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "broccoli-plugin": "^1.2.1",
-                "fs-tree-diff": "^0.5.2",
-                "heimdalljs": "^0.2.1",
-                "heimdalljs-logger": "^0.1.7",
-                "symlink-or-copy": "^1.1.8",
-                "tree-sync": "^1.2.2"
-            }
-        },
-        "node_modules/broccoli-debug/node_modules/broccoli-plugin": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-            "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "promise-map-series": "^0.2.1",
-                "quick-temp": "^0.1.3",
-                "rimraf": "^2.3.4",
-                "symlink-or-copy": "^1.1.8"
-            }
-        },
-        "node_modules/broccoli-funnel": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-            "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-equal": "^1.0.0",
-                "blank-object": "^1.0.1",
-                "broccoli-plugin": "^1.3.0",
-                "debug": "^2.2.0",
-                "fast-ordered-set": "^1.0.0",
-                "fs-tree-diff": "^0.5.3",
-                "heimdalljs": "^0.2.0",
-                "minimatch": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "path-posix": "^1.0.0",
-                "rimraf": "^2.4.3",
-                "symlink-or-copy": "^1.0.0",
-                "walk-sync": "^0.3.1"
-            },
-            "engines": {
-                "node": "^4.5 || 6.* || >= 7.*"
-            }
-        },
-        "node_modules/broccoli-funnel/node_modules/broccoli-plugin": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-            "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "promise-map-series": "^0.2.1",
-                "quick-temp": "^0.1.3",
-                "rimraf": "^2.3.4",
-                "symlink-or-copy": "^1.1.8"
-            }
-        },
-        "node_modules/broccoli-funnel/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/broccoli-funnel/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/broccoli-funnel/node_modules/walk-sync": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
-            "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ensure-posix-path": "^1.0.0",
-                "matcher-collection": "^1.0.0"
-            }
-        },
-        "node_modules/broccoli-kitchen-sink-helpers": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
-            "integrity": "sha512-gqYnKSJxBSjj/uJqeuRAzYVbmjWhG0mOZ8jrp6+fnUIOgLN6MvI7XxBECDHkYMIFPJ8Smf4xaI066Q2FqQDnXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "glob": "^5.0.10",
-                "mkdirp": "^0.5.1"
-            }
-        },
-        "node_modules/broccoli-kitchen-sink-helpers/node_modules/glob": {
-            "version": "5.0.15",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-            "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "2 || 3",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/broccoli-merge-trees": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
-            "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "broccoli-plugin": "^1.3.0",
-                "merge-trees": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/broccoli-merge-trees/node_modules/broccoli-plugin": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-            "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "promise-map-series": "^0.2.1",
-                "quick-temp": "^0.1.3",
-                "rimraf": "^2.3.4",
-                "symlink-or-copy": "^1.1.8"
-            }
-        },
-        "node_modules/broccoli-persistent-filter": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
-            "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "async-disk-cache": "^1.2.1",
-                "async-promise-queue": "^1.0.3",
-                "broccoli-plugin": "^1.0.0",
-                "fs-tree-diff": "^2.0.0",
-                "hash-for-dep": "^1.5.0",
-                "heimdalljs": "^0.2.1",
-                "heimdalljs-logger": "^0.1.7",
-                "mkdirp": "^0.5.1",
-                "promise-map-series": "^0.2.1",
-                "rimraf": "^2.6.1",
-                "rsvp": "^4.7.0",
-                "symlink-or-copy": "^1.0.1",
-                "sync-disk-cache": "^1.3.3",
-                "walk-sync": "^1.0.0"
-            },
-            "engines": {
-                "node": "6.* || >= 8.*"
-            }
-        },
-        "node_modules/broccoli-persistent-filter/node_modules/broccoli-plugin": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-            "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "promise-map-series": "^0.2.1",
-                "quick-temp": "^0.1.3",
-                "rimraf": "^2.3.4",
-                "symlink-or-copy": "^1.1.8"
-            }
-        },
-        "node_modules/broccoli-persistent-filter/node_modules/fs-tree-diff": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-            "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/symlink-or-copy": "^1.2.0",
-                "heimdalljs-logger": "^0.1.7",
-                "object-assign": "^4.1.0",
-                "path-posix": "^1.0.0",
-                "symlink-or-copy": "^1.1.8"
-            },
-            "engines": {
-                "node": "6.* || 8.* || >= 10.*"
-            }
-        },
-        "node_modules/broccoli-plugin": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz",
-            "integrity": "sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "promise-map-series": "^0.2.1",
-                "quick-temp": "^0.1.3",
-                "rimraf": "^2.3.4",
-                "symlink-or-copy": "^1.1.8"
-            },
-            "engines": {
-                "node": "6.* || 8.* || >= 10.*"
-            }
-        },
-        "node_modules/broccoli-stew": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-3.0.0.tgz",
-            "integrity": "sha512-NXfi+Vas24n3Ivo21GvENTI55qxKu7OwKRnCLWXld8MiLiQKQlWIq28eoARaFj0lTUFwUa4jKZeA7fW9PiWQeg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "broccoli-debug": "^0.6.5",
-                "broccoli-funnel": "^2.0.0",
-                "broccoli-merge-trees": "^3.0.1",
-                "broccoli-persistent-filter": "^2.3.0",
-                "broccoli-plugin": "^2.1.0",
-                "chalk": "^2.4.1",
-                "debug": "^4.1.1",
-                "ensure-posix-path": "^1.0.1",
-                "fs-extra": "^8.0.1",
-                "minimatch": "^3.0.4",
-                "resolve": "^1.11.1",
-                "rsvp": "^4.8.5",
-                "symlink-or-copy": "^1.2.0",
-                "walk-sync": "^1.1.3"
-            },
-            "engines": {
-                "node": "8.* || >= 10.*"
             }
         },
         "node_modules/browser-stdout": {
@@ -2260,31 +1845,6 @@
             },
             "engines": {
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-            }
-        },
-        "node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
             }
         },
         "node_modules/byte-size": {
@@ -2389,32 +1949,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/can-symlink": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
-            "integrity": "sha512-RbsNrFyhwkx+6psk/0fK/Q9orOUr9VMxohGd8vTa4djf4TGLfblBgUfqZChrZuW0Q+mz2eBPFLusw9Jfukzmhg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tmp": "0.0.28"
-            },
-            "bin": {
-                "can-symlink": "can-symlink.js"
-            }
-        },
-        "node_modules/can-symlink/node_modules/tmp": {
-            "version": "0.0.28",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-            "integrity": "sha512-c2mmfiBmND6SOVxzogm1oda0OJ1HZVIk/5n26N59dDTh80MUeavpiCls4PGAdkX1PFkKokLpcf7prSjCeXLsJg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "os-tmpdir": "~1.0.1"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/caniuse-lite": {
@@ -2583,39 +2117,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/clean-up-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/clean-up-path/-/clean-up-path-1.0.0.tgz",
-            "integrity": "sha512-PHGlEF0Z6976qQyN6gM7kKH6EH0RdfZcc8V+QhFe36eRxV0SMH5OUBZG7Bxa9YcreNzyNbK63cGiZxdSZgosRw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/cli-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "restore-cursor": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-spinners": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/cliui": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2625,16 +2126,6 @@
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^7.0.0"
-            }
-        },
-        "node_modules/clone": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-            "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8"
             }
         },
         "node_modules/co": {
@@ -2664,16 +2155,6 @@
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/colors": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.1.90"
-            }
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
@@ -2739,16 +2220,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/commander": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 12"
-            }
-        },
         "node_modules/common-log-format": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/common-log-format/-/common-log-format-1.0.0.tgz",
@@ -2781,6 +2252,13 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/content-tag": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/content-tag/-/content-tag-2.0.3.tgz",
+            "integrity": "sha512-htLIdtfhhKW2fHlFLnZH7GFzHSdSpHhDLrWVswkNiiPMZ5uXq5JfrGboQKFhNQuAAFF8VNB2EYUj3MsdJrKKpg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/content-type": {
             "version": "1.0.5",
@@ -2857,13 +2335,13 @@
             }
         },
         "node_modules/css-tree": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+            "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "mdn-data": "2.0.30",
+                "mdn-data": "2.12.2",
                 "source-map-js": "^1.0.1"
             },
             "engines": {
@@ -3001,19 +2479,6 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/defaults": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-            "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "clone": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
@@ -3159,16 +2624,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/editions": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-            "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3183,42 +2638,50 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/ember-cli-babel-plugin-helpers": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz",
-            "integrity": "sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "6.* || 8.* || >= 10.*"
-            }
-        },
-        "node_modules/ember-cli-version-checker": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
-            "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "resolve-package-path": "^3.1.0",
-                "semver": "^7.3.4",
-                "silent-error": "^1.1.1"
-            },
-            "engines": {
-                "node": "10.* || >= 12.*"
-            }
-        },
-        "node_modules/ember-cli-version-checker/node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+        "node_modules/ember-eslint-parser": {
+            "version": "0.5.13",
+            "resolved": "https://registry.npmjs.org/ember-eslint-parser/-/ember-eslint-parser-0.5.13.tgz",
+            "integrity": "sha512-b6ALDaxs9Bb4v0uagWud/5lECb78qpXHFv7M340dUHFW4Y0RuhlsfA4Rb+765X1+6KHp8G7TaAs0UgggWUqD3g==",
             "dev": true,
             "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
+            "dependencies": {
+                "@babel/eslint-parser": "^7.23.10",
+                "@glimmer/syntax": ">= 0.92.0",
+                "@typescript-eslint/tsconfig-utils": "^8.38.0",
+                "content-tag": "^2.0.1",
+                "eslint-scope": "^7.2.2",
+                "html-tags": "^3.3.1",
+                "mathml-tag-names": "^2.1.3",
+                "svg-tags": "^1.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.23.6",
+                "@typescript-eslint/parser": "*"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/parser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ember-eslint-parser/node_modules/eslint-scope": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/ember-rfc176-data": {
@@ -3227,63 +2690,6 @@
             "integrity": "sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/ember-template-imports": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-3.4.2.tgz",
-            "integrity": "sha512-OS8TUVG2kQYYwP3netunLVfeijPoOKIs1SvPQRTNOQX4Pu8xGGBEZmrv0U1YTnQn12Eg+p6w/0UdGbUnITjyzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-import-util": "^0.2.0",
-                "broccoli-stew": "^3.0.0",
-                "ember-cli-babel-plugin-helpers": "^1.1.1",
-                "ember-cli-version-checker": "^5.1.2",
-                "line-column": "^1.0.2",
-                "magic-string": "^0.25.7",
-                "parse-static-imports": "^1.1.0",
-                "string.prototype.matchall": "^4.0.6",
-                "validate-peer-dependencies": "^1.1.0"
-            },
-            "engines": {
-                "node": "12.* || >= 14"
-            }
-        },
-        "node_modules/ember-template-imports/node_modules/magic-string": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-            "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sourcemap-codec": "^1.4.8"
-            }
-        },
-        "node_modules/ember-template-recast": {
-            "version": "6.1.5",
-            "resolved": "https://registry.npmjs.org/ember-template-recast/-/ember-template-recast-6.1.5.tgz",
-            "integrity": "sha512-VnRN8FzEHQnw/5rCv6Wnq8MVYXbGQbFY+rEufvWV+FO/IsxMahGEud4MYWtTA2q8iG+qJFrDQefNvQ//7MI7Qw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@glimmer/reference": "^0.84.3",
-                "@glimmer/syntax": "^0.84.3",
-                "@glimmer/validator": "^0.84.3",
-                "async-promise-queue": "^1.0.5",
-                "colors": "^1.4.0",
-                "commander": "^8.3.0",
-                "globby": "^11.0.3",
-                "ora": "^5.4.0",
-                "slash": "^3.0.0",
-                "tmp": "^0.2.1",
-                "workerpool": "^6.4.0"
-            },
-            "bin": {
-                "ember-template-recast": "lib/bin.js"
-            },
-            "engines": {
-                "node": "12.* || 14.* || >= 16.*"
-            }
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -3300,13 +2706,6 @@
             "engines": {
                 "node": ">= 0.8"
             }
-        },
-        "node_modules/ensure-posix-path": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
-            "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/es-abstract": {
             "version": "1.24.0",
@@ -3572,31 +2971,34 @@
             }
         },
         "node_modules/eslint-plugin-ember": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-11.12.0.tgz",
-            "integrity": "sha512-7Ow1ky5JnRR0k3cxuvgYi4AWTe9DzGjlLgOJbU5VABLgr7Q0iq3ioC+YwAP79nV48cpw2HOgMgkZ1MynuIg59g==",
+            "version": "12.7.5",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-12.7.5.tgz",
+            "integrity": "sha512-2zLEpu3xcKjykgsKkj8sU2GwdxADFTH5XPBvuIrNBP253JxHSz2P21isUuRB50kGoR2KL+eUHNgV0j7IPCav1w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@ember-data/rfc395-data": "^0.0.4",
-                "@glimmer/syntax": "^0.84.2",
-                "css-tree": "^2.0.4",
-                "ember-rfc176-data": "^0.3.15",
-                "ember-template-imports": "^3.4.2",
-                "ember-template-recast": "^6.1.4",
+                "css-tree": "^3.0.1",
+                "ember-eslint-parser": "^0.5.9",
+                "ember-rfc176-data": "^0.3.18",
                 "eslint-utils": "^3.0.0",
-                "estraverse": "^5.2.0",
-                "lodash.camelcase": "^4.1.1",
+                "estraverse": "^5.3.0",
+                "lodash.camelcase": "^4.3.0",
                 "lodash.kebabcase": "^4.1.1",
-                "magic-string": "^0.30.0",
                 "requireindex": "^1.2.0",
                 "snake-case": "^3.0.3"
             },
             "engines": {
-                "node": "14.* || 16.* || >= 18"
+                "node": "18.* || 20.* || >= 21"
             },
             "peerDependencies": {
-                "eslint": ">= 7"
+                "@typescript-eslint/parser": "*",
+                "eslint": ">= 8"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/parser": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-plugin-react": {
@@ -4005,16 +3407,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fast-ordered-set": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
-            "integrity": "sha512-MxBW4URybFszOx1YlACEoK52P6lE3xiFcPaGCUZ7QQOZ6uJXKo++Se8wa31SjcZ+NC/fdAWX7UtKEfaGgHS2Vg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "blank-object": "^1.0.1"
-            }
-        },
         "node_modules/fastq": {
             "version": "1.19.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4170,51 +3562,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/fs-tree-diff": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
-            "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "heimdalljs-logger": "^0.1.7",
-                "object-assign": "^4.1.0",
-                "path-posix": "^1.0.0",
-                "symlink-or-copy": "^1.1.8"
-            }
-        },
-        "node_modules/fs-updater": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/fs-updater/-/fs-updater-1.0.4.tgz",
-            "integrity": "sha512-0pJX4mJF/qLsNEwTct8CdnnRdagfb+LmjRPJ8sO+nCnAZLW0cTmz4rTgU25n+RvTuWSITiLKrGVJceJPBIPlKg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "can-symlink": "^1.0.0",
-                "clean-up-path": "^1.0.0",
-                "heimdalljs": "^0.2.5",
-                "heimdalljs-logger": "^0.1.9",
-                "rimraf": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/fs.realpath": {
@@ -4454,13 +3801,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/graphemer": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -4547,32 +3887,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/hash-for-dep": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.5.1.tgz",
-            "integrity": "sha512-/dQ/A2cl7FBPI2pO0CANkvuuVi/IFS5oTyJ0PsOb6jW6WbVW1js5qJXMJTNbWHXBIPdFTWFbabjB+mE0d+gelw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "broccoli-kitchen-sink-helpers": "^0.3.1",
-                "heimdalljs": "^0.2.3",
-                "heimdalljs-logger": "^0.1.7",
-                "path-root": "^0.1.1",
-                "resolve": "^1.10.0",
-                "resolve-package-path": "^1.0.11"
-            }
-        },
-        "node_modules/hash-for-dep/node_modules/resolve-package-path": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-1.2.7.tgz",
-            "integrity": "sha512-fVEKHGeK85bGbVFuwO9o1aU0n3vqQGrezPc51JGu9UTXpFQfWq5qCeKxyaRUSvephs+06c5j5rPq/dzHGEo8+Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-root": "^0.1.1",
-                "resolve": "^1.10.0"
-            }
-        },
         "node_modules/hasown": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -4595,50 +3909,18 @@
                 "he": "bin/he"
             }
         },
-        "node_modules/heimdalljs": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
-            "integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
+        "node_modules/html-tags": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+            "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "rsvp": "~3.2.1"
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/heimdalljs-logger": {
-            "version": "0.1.10",
-            "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.10.tgz",
-            "integrity": "sha512-pO++cJbhIufVI/fmB/u2Yty3KJD0TqNPecehFae0/eps0hkZ3b4Zc/PezUMOpYuHFQbA7FxHZxa305EhmjLj4g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^2.2.0",
-                "heimdalljs": "^0.2.6"
-            }
-        },
-        "node_modules/heimdalljs-logger/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/heimdalljs-logger/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/heimdalljs/node_modules/rsvp": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-            "integrity": "sha512-Rf4YVNYpKjZ6ASAmibcwTNciQ5Co5Ztq6iZPEykHpkoflnD/K5ryE/rHehFsTm4NJj8nKDhbi3eKBWGogmNnkg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/http-assert": {
             "version": "1.5.0",
@@ -4680,27 +3962,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
             "version": "5.3.2",
@@ -5011,16 +4272,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-interactive": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/is-map": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -5279,34 +4530,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/isobject": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "isarray": "1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/istextorbinary": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
-            "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "binaryextensions": "1 || 2",
-                "editions": "^1.1.1",
-                "textextensions": "1 || 2"
-            },
-            "engines": {
-                "node": ">=0.12"
-            }
-        },
         "node_modules/iterator.prototype": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -5333,9 +4556,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5390,16 +4613,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "dev": true,
-            "license": "MIT",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/jsonparse": {
@@ -5522,9 +4735,9 @@
             }
         },
         "node_modules/koa": {
-            "version": "2.16.2",
-            "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.2.tgz",
-            "integrity": "sha512-+CCssgnrWKx9aI3OeZwroa/ckG4JICxvIFnSiOUyl2Uv+UTI+xIw0FfFrWS7cQFpoePpr9o8csss7KzsTzNL8Q==",
+            "version": "2.16.3",
+            "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.3.tgz",
+            "integrity": "sha512-zPPuIt+ku1iCpFBRwseMcPYQ1cJL8l60rSmKeOuGfOXyE6YnTBmf2aEFNL2HQGrD0cPcLO/t+v9RTgC+fwEh/g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5648,17 +4861,6 @@
             "license": "MIT",
             "dependencies": {
                 "immediate": "~3.0.5"
-            }
-        },
-        "node_modules/line-column": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
-            "integrity": "sha512-Ktrjk5noGYlHsVnYWh62FLVs4hTb8A3e+vucNZMgPeAOITdshMSgv4cCZQeRDjm7+goqmo6+liZwTXo+U3sVww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "isarray": "^1.0.0",
-                "isobject": "^2.0.0"
             }
         },
         "node_modules/load-module": {
@@ -6051,26 +5253,6 @@
                 "node": ">=12.17"
             }
         },
-        "node_modules/magic-string": {
-            "version": "0.30.19",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-            "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.5.5"
-            }
-        },
-        "node_modules/matcher-collection": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-            "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "minimatch": "^3.0.2"
-            }
-        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6080,10 +5262,21 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/mathml-tag-names": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+            "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/mdn-data": {
-            "version": "2.0.30",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+            "version": "2.12.2",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+            "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
             "dev": true,
             "license": "CC0-1.0"
         },
@@ -6095,17 +5288,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/merge-trees": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
-            "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fs-updater": "^1.0.4",
-                "heimdalljs": "^0.2.5"
             }
         },
         "node_modules/merge2": {
@@ -6153,16 +5335,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6174,39 +5346,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/minimist": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
-        "node_modules/mktemp": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
-            "integrity": "sha512-IXnMcJ6ZyTuhRmJSjzvHSRhlVPiN9Jwc6e59V0bEJ0ba6OBeX2L0E+mRN1QseeOF4mM+F1Rit6Nh7o+rl2Yn/A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">0.9"
             }
         },
         "node_modules/mocha": {
@@ -6622,22 +5761,6 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/only": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
@@ -6678,116 +5801,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/ora": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bl": "^4.1.0",
-                "chalk": "^4.1.0",
-                "cli-cursor": "^3.1.0",
-                "cli-spinners": "^2.5.0",
-                "is-interactive": "^1.0.0",
-                "is-unicode-supported": "^0.1.0",
-                "log-symbols": "^4.1.0",
-                "strip-ansi": "^6.0.0",
-                "wcwidth": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ora/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/ora/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/ora/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/ora/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/ora/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/ora/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/own-keys": {
@@ -6860,13 +5873,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/parse-static-imports": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/parse-static-imports/-/parse-static-imports-1.1.0.tgz",
-            "integrity": "sha512-HlxrZcISCblEV0lzXmAHheH/8qEkKgmqkdxyHTPbSqsTUV8GzqmN1L+SSti+VbNPfbBO3bYLPHDiUs2avbAdbA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -6913,36 +5919,6 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/path-posix": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-            "integrity": "sha512-1gJ0WpNIiYcQydgg3Ed8KzvIqTsDpNwq+cjBCssvBtuTWjEqY1AW+i+OepiEMqDCzyro9B2sLAe4RBPajMYFiA==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/path-root": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-            "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-root-regex": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/path-root-regex": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-            "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/path-to-regexp": {
             "version": "6.3.0",
@@ -7038,26 +6014,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/promise-map-series": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
-            "integrity": "sha512-wx9Chrutvqu1N/NHzTayZjE1BgIwt6SJykQoCOic4IZ9yUDjKyVYrpLa/4YCNsV61eRENfs29hrEquVuB13Zlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "rsvp": "^3.0.14"
-            }
-        },
-        "node_modules/promise-map-series/node_modules/rsvp": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "0.12.* || 4.* || 6.* || >= 7.*"
-            }
-        },
         "node_modules/prop-types": {
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7110,18 +6066,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/quick-temp": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
-            "integrity": "sha512-YsmIFfD9j2zaFwJkzI6eMG7y0lQP7YeWzgtFgNl38pGWZBSXJooZbOWwkcRot7Vt0Fg9L23pX0tqWU3VvLDsiA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mktemp": "~0.4.0",
-                "rimraf": "^2.5.4",
-                "underscore.string": "~3.3.4"
-            }
-        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -7138,21 +6082,6 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
@@ -7246,27 +6175,6 @@
                 "node": ">=0.10.5"
             }
         },
-        "node_modules/resolve": {
-            "version": "1.22.10",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.16.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -7275,20 +6183,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/resolve-package-path": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
-            "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-root": "^0.1.1",
-                "resolve": "^1.17.0"
-            },
-            "engines": {
-                "node": "10.* || >= 12"
             }
         },
         "node_modules/resolve-path": {
@@ -7345,20 +6239,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/restore-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7368,30 +6248,6 @@
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
-        "node_modules/rsvp": {
-            "version": "4.8.5",
-            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-            "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "6.* || >= 7.*"
             }
         },
         "node_modules/run-parallel": {
@@ -7797,40 +6653,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/silent-error": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.1.1.tgz",
-            "integrity": "sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "debug": "^2.2.0"
-            }
-        },
-        "node_modules/silent-error/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/silent-error/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/simple-html-tokenizer": {
             "version": "0.5.11",
             "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
@@ -7910,21 +6732,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/sourcemap-codec": {
-            "version": "1.4.8",
-            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-            "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "dev": true,
-            "license": "BSD-3-Clause"
         },
         "node_modules/statuses": {
             "version": "1.5.0",
@@ -8187,42 +6994,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/symlink-or-copy": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.3.1.tgz",
-            "integrity": "sha512-0K91MEXFpBUaywiwSSkmKjnGcasG/rVBXFLJz5DrgGabpYD6N+3yZrfD6uUIfpuTu65DZLHi7N8CizHc07BPZA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/sync-disk-cache": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
-            "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^2.1.3",
-                "heimdalljs": "^0.2.3",
-                "mkdirp": "^0.5.0",
-                "rimraf": "^2.2.8",
-                "username-sync": "^1.0.2"
-            }
-        },
-        "node_modules/sync-disk-cache/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/sync-disk-cache/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
+        "node_modules/svg-tags": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+            "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+            "dev": true
         },
         "node_modules/table-layout": {
             "version": "1.0.2",
@@ -8266,19 +7042,6 @@
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/textextensions": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.6.0.tgz",
-            "integrity": "sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8"
-            },
-            "funding": {
-                "url": "https://bevry.me/fund"
-            }
         },
         "node_modules/through": {
             "version": "2.3.8",
@@ -8325,48 +7088,6 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "license": "MIT"
-        },
-        "node_modules/tree-sync": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.4.0.tgz",
-            "integrity": "sha512-YvYllqh3qrR5TAYZZTXdspnIhlKAYezPYw11ntmweoceu4VK+keN356phHRIIo1d+RDmLpHZrUlmxga2gc9kSQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "debug": "^2.2.0",
-                "fs-tree-diff": "^0.5.6",
-                "mkdirp": "^0.5.1",
-                "quick-temp": "^0.1.5",
-                "walk-sync": "^0.3.3"
-            }
-        },
-        "node_modules/tree-sync/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/tree-sync/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/tree-sync/node_modules/walk-sync": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
-            "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ensure-posix-path": "^1.0.0",
-                "matcher-collection": "^1.0.0"
-            }
         },
         "node_modules/tslib": {
             "version": "2.8.1",
@@ -8579,35 +7300,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/underscore.string": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.6.tgz",
-            "integrity": "sha512-VoC83HWXmCrF6rgkyxS9GHv8W9Q5nhMKho+OadDJGzL2oDYbYEppBaCMH6pFlwLeqj2QS+hhkw2kpXkSdD1JxQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "^1.1.1",
-                "util-deprecate": "^1.0.2"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/undici-types": {
             "version": "7.16.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
             "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
             "license": "MIT"
-        },
-        "node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
         },
         "node_modules/update-browserslist-db": {
             "version": "1.1.3",
@@ -8650,43 +7347,12 @@
                 "punycode": "^2.1.0"
             }
         },
-        "node_modules/username-sync": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/username-sync/-/username-sync-1.0.3.tgz",
-            "integrity": "sha512-m/7/FSqjJNAzF2La448c/aEom0gJy7HY7Y509h6l0ePvEkFictAGptwWaj1msWJ38JbfEDOUoE8kqFee9EHKdA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/validate-peer-dependencies": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/validate-peer-dependencies/-/validate-peer-dependencies-1.2.0.tgz",
-            "integrity": "sha512-nd2HUpKc6RWblPZQ2GDuI65sxJ2n/UqZwSBVtj64xlWjMx0m7ZB2m9b2JS3v1f+n9VWH/dd1CMhkHfP6pIdckA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "resolve-package-path": "^3.1.0",
-                "semver": "^7.3.2"
-            }
-        },
-        "node_modules/validate-peer-dependencies/node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/vary": {
             "version": "1.1.2",
@@ -8774,28 +7440,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.17"
-            }
-        },
-        "node_modules/walk-sync": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
-            "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/minimatch": "^3.0.3",
-                "ensure-posix-path": "^1.1.0",
-                "matcher-collection": "^1.1.1"
-            }
-        },
-        "node_modules/wcwidth": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-            "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "defaults": "^1.0.3"
             }
         },
         "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "command-line-usage": "^6.1.3",
         "es-main": "^1.3.0",
         "eslint": "^8.38.0",
-        "eslint-plugin-ember": "^11.4.8",
+        "eslint-plugin-ember": "^12.7.5",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-vue": "^9.10.0",
         "expect.js": "^0.3.1",


### PR DESCRIPTION
When running `npm install` one would get:
```
10 vulnerabilities (8 low, 2 moderate)

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
```

After this PR, it's fixed:
```
found 0 vulnerabilities
```

(I suppose we could also remove a bunch of dependencies, but let's do that later.)