### PR TITLE
Add information about platform support to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Those workloads help us to evaluate the performance of the implementation, e.g.,
 The runner, which allows to select workloads, including ones from external sources, and collects and displays metrics, is based on the [Speedometer runner](https://github.com/WebKit/Speedometer).
 See the Speedometer repo for a more detailed explanation, e.g., in which phases workloads are run and measured.
 
+## Platform Support
+
+The `main` branch is tested and is runnable on MacBook Pro (M3). If you want to run the benchmark on gLinux machines, please use the `running-models-on-glinux` branch.
+
 ## Setup Instructions, How to Run Workloads
 
 - Prerequisites: NPM, node. `npm install` to install the dependencies of the runner.


### PR DESCRIPTION
Some of the quantized version of the models do not work on gLinux machine. So, I have created `running-models-on-glinux` branch that runs on gLinux systems. 

This is a temporary solution for this problem. Let's add this note to the README.md file for now to be able to keep smaller models in the main branch. I opened issue #42 and I will fix it soon.