### PR TITLE
Use simpler suite names

### DIFF
--- a/resources/default-tests.mjs
+++ b/resources/default-tests.mjs
@@ -68,7 +68,7 @@ export const defaultSuites = [
         type: "remote",
     },
     {
-        name: "SFW Image-Classification-webgpu",
+        name: "SFW-Image-Classification-webgpu",
         url: "resources/transformers-js/dist/image-classification-gpu.html",
         tags: ["default", "image-classification", "webgpu", "transformers-js"],
         type: "remote",


### PR DESCRIPTION
Fix issue #44 

Use suite names without spaces and parenthesis for more readable url-params and cli args.