### PR TITLE
Skip downloading litert models if they already exist.

### DIFF
--- a/resources/shared/download-cache.mjs
+++ b/resources/shared/download-cache.mjs
@@ -4,10 +4,10 @@ export default class DownloadCache {
     cached = {};
 
     constructor(filename, force) {
+        this.filename = filename;
         if (force) {
             return;
         }
-        this.filename = filename;
         if (fs.existsSync(filename)) {
             try {
                 this.cached = JSON.parse(fs.readFileSync(filename, 'utf8'));


### PR DESCRIPTION
Implement a caching mechanism using a JSON file to track the state of downloaded models. This avoids redundant downloads during prebuild if the model configuration has not changed.

A --force flag is also added to allow users to manually bypass the cache and re-download all models when necessary.

Fixes a bug in the download cache where the filename wasn't defined when using `--force`.