### PR TITLE
Add information to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@
                         Do not run this on a metered connection; a stable broadband connection is highly recommended.
                         Additionally, the first iteration of the benchmark <b>may take several minutes</b> to complete.
                     </p>
+                    <p class="version-note">
+                        Version: <!-- package-version -->0.0.1-alpha<!-- /package-version --> (commit: <!-- git-hash --><a href="https://github.com/GoogleChrome/webai-compute-benchmark/commit/8c4bc60fac850c917fabb9eba9dec90c8f9a9bf5" target="_blank">8c4bc60</a><!-- /git-hash -->)
+                    </p>
                     <p id="screen-size-warning">
                         <strong>
                             Your browser window is too small. For most accurate results, please make the view port size at least <span id="min-screen-width">850px</span> by <span id="min-screen-height">650px</span>.<br />

--- a/resources/main.css
+++ b/resources/main.css
@@ -167,10 +167,6 @@ li + ul {
     flex-direction: column;
 }
 
-section#home > .buttons {
-    margin-top: 80px;
-}
-
 .button-row {
     display: flex;
     flex-wrap: wrap;
@@ -371,7 +367,11 @@ section#home p {
 
 section#home .content {
     margin-top: 100px;
-    text-align: center;
+}
+
+section#home .version-note {
+    color: var(--inactive-color);
+    text-align: right;
 }
 
 button.show-about {


### PR DESCRIPTION
three pieces of information:
1. A short description of the benchmark, including a link to the more in-depth README;
2. A note on download sizes / network transfers so that users are patient on not running this, e.g., on a mobile connection;
3. The package version and git commit hash.

Looks like this:
<img width="1220" height="910" alt="image" src="https://github.com/user-attachments/assets/d9bf4e2b-b8cd-4c9e-b6ec-a8f210ccb29a" />
