### PR TITLE
Show detailed results by default

### DIFF
--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -154,10 +154,7 @@ class MainBenchmarkClient {
             this._populateInvalidScore();
 
         this._populateDetailedResults(metrics);
-        if (params.developerMode)
-            this.showResultsDetails();
-        else
-            this.showResultsSummary();
+        this.showResultsDetails();
         globalThis.dispatchEvent(new Event("BenchmarkDone"));
     }
 
@@ -435,7 +432,7 @@ class MainBenchmarkClient {
             return;
         } else if (this._hasResults) {
             if (hash !== "#summary" && hash !== "#details") {
-                this._setLocationHash("#summary");
+                this._setLocationHash("#details");
                 return;
             }
         } else if (hash !== "#home" && hash !== "") {


### PR DESCRIPTION
I didn't remove the summary and gauge completely, maybe we want to use that later, once the set of workloads and metrics is more stable than today.