### PR TITLE
Minor developer menu style fixes

### DIFF
--- a/resources/developer-mode.mjs
+++ b/resources/developer-mode.mjs
@@ -7,13 +7,10 @@ export function createDeveloperModeContainer() {
     const container = document.createElement("div");
     container.className = "developer-mode";
 
-    const details = document.createElement("details");
+    const content = document.createElement("details");
     const summary = document.createElement("summary");
     summary.textContent = "Developer Mode";
-    details.append(summary);
-
-    const content = document.createElement("div");
-    content.className = "developer-mode-content";
+    content.appendChild(summary);
 
     content.append(createUIForSuites());
 
@@ -33,8 +30,7 @@ export function createDeveloperModeContainer() {
     content.append(document.createElement("hr"));
     content.append(createUIForRun());
 
-    details.append(content);
-    container.append(details);
+    container.append(content);
     return container;
 }
 
@@ -78,7 +74,7 @@ function createCheckboxUI(labelValue, initialValue, paramsUpdateCallback) {
 }
 
 function createUIForIterationCount() {
-    return createTimeRangeUI("Iterations: ", "iterationCount", "#", 1, 200);
+    return createTimeRangeUI("Iterations: ", "iterationCount", "#", 1, 50);
 }
 
 function createUIForWarmupBeforeSync() {

--- a/resources/main.css
+++ b/resources/main.css
@@ -230,7 +230,7 @@ button,
 
 .developer-mode {
     border-radius: 10px;
-    padding: 1rem 1rem 0 1rem;
+    padding: 1rem;
     background: #602525;
     border: 3px solid rgba(255, 255, 255, 0.5);
     position: fixed;
@@ -241,12 +241,6 @@ button,
 .developer-mode summary {
     user-select: none;
     cursor: pointer;
-    padding: 1rem;
-    margin: -1rem -1rem 0 -1rem;
-}
-
-.developer-mode-content {
-    padding-bottom: 1rem;
 }
 
 .developer-mode .suites {
@@ -256,47 +250,47 @@ button,
     overflow: auto;
 }
 
-.developer-mode-content ol {
+.developer-mode ol {
     list-style: none;
     padding: 0;
     margin: 0.5em 0 0 0;
 }
-.developer-mode-content .button-bar {
+.developer-mode .button-bar {
     display: flex;
     margin-top: 5px;
     gap: 3px;
 }
 
-.developer-mode-content .select-all::before {
+.developer-mode .select-all::before {
     content: "✔ ";
 }
 
-.developer-mode-content .unselect-all::after {
+.developer-mode .unselect-all::after {
     content: " ✘";
 }
 
-.developer-mode-content .settings label {
+.developer-mode .settings label {
     width: 100%;
     display: flex;
 }
-.developer-mode-content .settings label * {
+.developer-mode .settings label * {
     flex: 1;
 }
-.developer-mode-content .settings input[type="checkbox"] {
+.developer-mode .settings input[type="checkbox"] {
     flex: 0;
     margin-left: 0px;
 }
-.developer-mode-content .settings .range-label-data {
+.developer-mode .settings .range-label-data {
     flex: 0;
     min-width: 5em;
     text-align: right;
 }
 
-.developer-mode-content li + li {
+.developer-mode li + li {
     margin-top: 0px;
 }
 
-.developer-mode-content button {
+.developer-mode button {
     font-size: 16px;
     background: white;
     flex: auto;
@@ -306,7 +300,7 @@ button,
     border-radius: 10px;
 }
 
-.developer-mode-content button span {
+.developer-mode button span {
     padding-left: 10px;
     font-size: 1.5em;
     line-height: 10px;
@@ -314,15 +308,15 @@ button,
     top: 2px;
 }
 
-.developer-mode-content .tag {
+.developer-mode .tag {
     border-radius: 100vh;
 }
 
-.developer-mode-content .step-button {
+.developer-mode .step-button {
     color: white;
     background: rgba(255, 255, 255, 0.1);
 }
-.developer-mode-content hr {
+.developer-mode hr {
     width: initial;
     margin: 10px 0;
 }


### PR DESCRIPTION
- Avoid detail / container element overflowing below page bottom.
- Remove unnecessary intermediate `developer-mode-content` div.
- Simplify CSS.
- Change iterations range UI to have lower max instead of 200 (which would take way too long anyway).