### PR TITLE
Remove async measurement from experimental workloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
                         Additionally, the first iteration of the benchmark <b>may take several minutes</b> to complete.
                     </p>
                     <p class="version-note">
-                        Version: <!-- package-version -->0.0.1-alpha<!-- /package-version --> (commit: <!-- git-hash --><a href="https://github.com/GoogleChrome/webai-compute-benchmark/commit/582cd6a2dde29b5e03e2e1d68a2ac4a7dfed00fa" target="_blank">582cd6a</a><!-- /git-hash -->)
+                        Version: <!-- package-version -->0.0.1-alpha<!-- /package-version --> (commit: <!-- git-hash --><a href="https://github.com/GoogleChrome/webai-compute-benchmark/commit/c7ccce526e84318e5fcb184fa81fd68a92bc4be3" target="_blank">c7ccce5</a><!-- /git-hash -->)
                     </p>
                     <p id="screen-size-warning">
                         <strong>

--- a/resources/experimental/src/index.mjs
+++ b/resources/experimental/src/index.mjs
@@ -1,5 +1,4 @@
-import { BenchmarkConnector } from "speedometer-utils/benchmark.mjs";
-import { AsyncBenchmarkStep, AsyncBenchmarkSuite } from "speedometer-utils/benchmark.mjs";
+import { BenchmarkConnector, AsyncBenchmarkStep, AsyncBenchmarkSuite } from "speedometer-utils/benchmark.mjs";
 import { forceLayout } from "speedometer-utils/helpers.mjs";
 import { pipeline, env } from '@huggingface/transformers';
 
@@ -76,8 +75,8 @@ export async function initializeBenchmark(modelType) {
               forceLayout();
               await benchmark.run();
               forceLayout();
-          }),
-      ], true),
+          }, { measureAsync: false }),
+     ]),
   };
 
   const benchmarkConnector = new BenchmarkConnector(suites, appName, appVersion);


### PR DESCRIPTION
In PR #46, the async measurement was removed from default workloads. We have also experimental workloads and in in this PR, we remove async measurements for them as well. After merging this PR, we can close Issue #13. 