### PR TITLE
Add wasm-only and webgpu-only scores

### DIFF
--- a/about.html
+++ b/about.html
@@ -18,8 +18,8 @@
                     <div class="section-content">
                         <h2>Benchmark Version</h2>
                         <ul>
-                            <li>Version: <!-- package-version -->0.2.0 (2026-07-14)<!-- /package-version --></li>
-                            <li>Git commit: <!-- git-commit-link --><a href="https://github.com/GoogleChrome/webai-compute-benchmark/commit/7d3410a74849c8950e8d390b127aa64e8fead920" target="_blank">7d3410a</a><!-- /git-commit-link --></li>
+                            <li>Version: <!-- package-version -->0.3.0 (2026-07-20)<!-- /package-version --></li>
+                            <li>Git commit: <!-- git-commit-link --><a href="https://github.com/GoogleChrome/webai-compute-benchmark/commit/8dbb93528d750d4bc10b58ee7b058fd1e8ff0afb" target="_blank">8dbb935</a><!-- /git-commit-link --></li>
                         </ul>
                         <h2>Library Versions</h2>
                         <ul>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
                         Additionally, the first iteration of the benchmark <b>may take several minutes</b> to complete.
                     </p>
                     <p class="version-note">
-                        Version: <!-- package-version -->0.2.0 (2026-07-14)<!-- /package-version --> (commit: <!-- git-commit-link --><a href="https://github.com/GoogleChrome/webai-compute-benchmark/commit/7d3410a74849c8950e8d390b127aa64e8fead920" target="_blank">7d3410a</a><!-- /git-commit-link -->)
+                        Version: <!-- package-version -->0.3.0 (2026-07-20)<!-- /package-version --> (commit: <!-- git-commit-link --><a href="https://github.com/GoogleChrome/webai-compute-benchmark/commit/8dbb93528d750d4bc10b58ee7b058fd1e8ff0afb" target="_blank">8dbb935</a><!-- /git-commit-link -->)
                     </p>
                     <p id="screen-size-warning">
                         <strong>
@@ -94,7 +94,7 @@
                     <div class="version next">next</div>
                 </a>
                 <div class="section-grid">
-                    <h1 class="section-header">Detailed Results <!-- package-version -->0.2.0 (2026-07-14)<!-- /package-version --></h1>
+                    <h1 class="section-header">Detailed Results <!-- package-version -->0.3.0 (2026-07-20)<!-- /package-version --></h1>
                     <div class="section-content all-metric-results">
                         <div class="non-standard-params">
                             <h2>Non-standard Parameters</h2>

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
                 </a>
                 <div class="scores-container">
                     <div class="score-box">
-                        <h2>WASM Score</h2>
+                        <h2>Wasm Score</h2>
                         <div id="wasm-result-number" class="score-value"></div>
                         <div id="wasm-confidence-number" class="score-confidence"></div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -66,13 +66,18 @@
                 <a href="#home" class="logo">
                     <div class="version next">next</div>
                 </a>
-                <h1>Score</h1>
-                <div class="gauge">
-                    <div class="window"><div class="needle"></div></div>
+                <div class="scores-container">
+                    <div class="score-box">
+                        <h2>WASM Score</h2>
+                        <div id="wasm-result-number" class="score-value"></div>
+                        <div id="wasm-confidence-number" class="score-confidence"></div>
+                    </div>
+                    <div class="score-box">
+                        <h2>WebGPU Score</h2>
+                        <div id="webgpu-result-number" class="score-value"></div>
+                        <div id="webgpu-confidence-number" class="score-confidence"></div>
+                    </div>
                 </div>
-                <hr />
-                <div id="result-number"></div>
-                <div id="confidence-number"></div>
                 <div id="invalid-score-text">
                     One or more subtests produced no duration.<br />
                     Please check your <a href="./instructions.html" target="_blank">browser settings</a> and re-run the benchmark.<br />

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
                             </table>
                         </div>
                         <div class="aggregated-metric-result">
-                            <h2>Aggregate Metric</h2>
+                            <h2>Benchmark Scores</h2>
                             <div id="aggregate-chart"></div>
                             <h2>Test Metrics Overview</h2>
                             <div id="tests-chart"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "webai-compute-benchmark",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "An open source repository for the Web AI Compute Benchmark.",
     "engines": {
         "node": ">=22.18.0",

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -474,27 +474,11 @@ export class BenchmarkRunner {
     async _finalize(iteration) {
         this._appendIterationMetrics(iteration);
         if (this._client?.didRunSuites) {
-            let wasmProduct = 1;
-            let wasmCount = 0;
-            let webgpuProduct = 1;
-            let webgpuCount = 0;
+            const iterationWasmMetric = this._metrics[`Iteration-${iteration}-WASM-Total`];
+            const iterationWebgpuMetric = this._metrics[`Iteration-${iteration}-WebGPU-Total`];
 
-            for (const suiteName in this._measuredValues.steps) {
-                const suiteTotal = this._measuredValues.steps[suiteName].total;
-                if (suiteTotal > 0) {
-                    const suite = this._suites.find(s => s.name === suiteName);
-                    if (suite?.tags?.includes("wasm")) {
-                        wasmProduct *= suiteTotal;
-                        wasmCount++;
-                    } else if (suite?.tags?.includes("webgpu")) {
-                        webgpuProduct *= suiteTotal;
-                        webgpuCount++;
-                    }
-                }
-            }
-
-            let wasmGeomean = wasmCount > 0 ? Math.pow(wasmProduct, 1 / wasmCount) : 0;
-            let webgpuGeomean = webgpuCount > 0 ? Math.pow(webgpuProduct, 1 / webgpuCount) : 0;
+            const wasmGeomean = !isNaN(iterationWasmMetric?.geomean) ? iterationWasmMetric.geomean : 0;
+            const webgpuGeomean = !isNaN(iterationWebgpuMetric?.geomean) ? iterationWebgpuMetric.geomean : 0;
 
             this._measuredValues.wasmGeomean = wasmGeomean;
             this._measuredValues.wasmScore = geomeanToScore(wasmGeomean);

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -219,7 +219,7 @@ class PageElement {
 }
 
 function geomeanToScore(geomean) {
-    return 100000 / geomean;
+    return 10000 / geomean;
 }
 
 // The WarmupSuite is used to make sure all runner helper functions and
@@ -347,7 +347,7 @@ export class BenchmarkRunner {
         const iterationEndLabel = "iteration-end";
         for (let i = 0; i < this._iterationCount; i++) {
             performance.mark(iterationStartLabel);
-            await this.runAllSuites();
+            await this.runAllSuites(i);
             performance.mark(iterationEndLabel);
             performance.measure(`iteration-${i}`, iterationStartLabel, iterationEndLabel);
         }
@@ -410,7 +410,7 @@ export class BenchmarkRunner {
         }
     }
 
-    async runAllSuites() {
+    async runAllSuites(iteration) {
         const suites = await this._prepareAllSuites();
         try {
             for (const suite of suites) {
@@ -447,16 +447,16 @@ export class BenchmarkRunner {
                 }
             }
         } finally {
-            await this._finishRunAllSuites();
+            await this._finishRunAllSuites(iteration);
         }
     }
 
-    async _finishRunAllSuites() {
+    async _finishRunAllSuites(iteration) {
         const finalizeStartLabel = "runner-finalize-start";
         const finalizeEndLabel = "runner-finalize-end";
 
         performance.mark(finalizeStartLabel);
-        await this._finalize();
+        await this._finalize(iteration);
         performance.mark(finalizeEndLabel);
         performance.measure("runner-finalize", finalizeStartLabel, finalizeEndLabel);
         await this._wakeLock.release();
@@ -471,8 +471,8 @@ export class BenchmarkRunner {
         await suiteRunner.run();
     }
 
-    async _finalize() {
-        this._appendIterationMetrics();
+    async _finalize(iteration) {
+        this._appendIterationMetrics(iteration);
         if (this._client?.didRunSuites) {
             let wasmProduct = 1;
             let wasmCount = 0;
@@ -505,7 +505,7 @@ export class BenchmarkRunner {
         }
     }
 
-    _appendIterationMetrics() {
+    _appendIterationMetrics(iteration) {
         const getMetric = (name, unit = "ms") => this._metrics[name] || (this._metrics[name] = new Metric(name, unit));
         const iterationMetric = (i, name) => {
             if (i >= params.iterationCount)
@@ -548,7 +548,6 @@ export class BenchmarkRunner {
 
         const wasmGeomean = getMetric("WASM-Geomean");
         const webgpuGeomean = getMetric("WebGPU-Geomean");
-        const iteration = wasmGeomean.length;
         const iterationWasmTotal = iterationMetric(iteration, "WASM-Total");
         const iterationWebgpuTotal = iterationMetric(iteration, "WebGPU-Total");
 

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -219,7 +219,7 @@ class PageElement {
 }
 
 function geomeanToScore(geomean) {
-    return 1000 / geomean;
+    return 100000 / geomean;
 }
 
 // The WarmupSuite is used to make sure all runner helper functions and
@@ -474,31 +474,33 @@ export class BenchmarkRunner {
     async _finalize() {
         this._appendIterationMetrics();
         if (this._client?.didRunSuites) {
-            let product = 1;
-            const values = [];
-            let total = 0;
-            let geomean = 0;
+            let wasmProduct = 1;
+            let wasmCount = 0;
+            let webgpuProduct = 1;
+            let webgpuCount = 0;
 
             for (const suiteName in this._measuredValues.steps) {
                 const suiteTotal = this._measuredValues.steps[suiteName].total;
                 if (suiteTotal > 0) {
-                    product *= suiteTotal;
-                    values.push(suiteTotal);
+                    const suite = this._suites.find(s => s.name === suiteName);
+                    if (suite?.tags?.includes("wasm")) {
+                        wasmProduct *= suiteTotal;
+                        wasmCount++;
+                    } else if (suite?.tags?.includes("webgpu")) {
+                        webgpuProduct *= suiteTotal;
+                        webgpuCount++;
+                    }
                 }
             }
 
-            let mean = 0;
-            if (values.length > 0) {
-                values.sort((a, b) => a - b); // Avoid the loss of significance for the sum.
-                total = values.reduce((a, b) => a + b, 0);
-                geomean = Math.pow(product, 1 / values.length);
-                mean = total / values.length;
-            }
+            let wasmGeomean = wasmCount > 0 ? Math.pow(wasmProduct, 1 / wasmCount) : 0;
+            let webgpuGeomean = webgpuCount > 0 ? Math.pow(webgpuProduct, 1 / webgpuCount) : 0;
 
-            this._measuredValues.total = total;
-            this._measuredValues.mean = mean;
-            this._measuredValues.geomean = geomean;
-            this._measuredValues.score = geomeanToScore(geomean);
+            this._measuredValues.wasmGeomean = wasmGeomean;
+            this._measuredValues.wasmScore = geomeanToScore(wasmGeomean);
+            this._measuredValues.webgpuGeomean = webgpuGeomean;
+            this._measuredValues.webgpuScore = geomeanToScore(webgpuGeomean);
+
             await this._client.didRunSuites(this._measuredValues);
         }
     }
@@ -531,26 +533,46 @@ export class BenchmarkRunner {
 
         if (initializeMetrics) {
             // Prepare all iteration metrics so they are listed at the end of
-            // of the _metrics object, before "Total" and "Score".
-            for (let i = 0; i < this._iterationCount; i++)
-                iterationMetric(i, "Total").description = `Test totals for iteration ${i}`;
-            getMetric("Geomean", "ms").description = "Geomean of test totals";
-            getMetric("Score", "score").description = "Scaled inverse of the Geomean";
+            // of the _metrics object.
+            for (let i = 0; i < this._iterationCount; i++) {
+                iterationMetric(i, "WASM-Total").description = `WASM test totals for iteration ${i}`;
+                iterationMetric(i, "WebGPU-Total").description = `WebGPU test totals for iteration ${i}`;
+            }
+            getMetric("WASM-Geomean", "ms").description = "Geomean of WASM test totals";
+            getMetric("WASM-Score", "score").description = "Scaled inverse of the WASM Geomean";
+            getMetric("WebGPU-Geomean", "ms").description = "Geomean of WebGPU test totals";
+            getMetric("WebGPU-Score", "score").description = "Scaled inverse of the WebGPU Geomean";
             if (params.measurePrepare)
                 getMetric("Prepare", "ms").description = "Geomean of workload prepare times";
         }
 
-        const geomean = getMetric("Geomean");
-        const iteration = geomean.length;
-        const iterationTotal = iterationMetric(iteration, "Total");
-        for (const results of Object.values(iterationResults)) {
-            if (results.total > 0)
-                iterationTotal.add(results.total);
+        const wasmGeomean = getMetric("WASM-Geomean");
+        const webgpuGeomean = getMetric("WebGPU-Geomean");
+        const iteration = wasmGeomean.length;
+        const iterationWasmTotal = iterationMetric(iteration, "WASM-Total");
+        const iterationWebgpuTotal = iterationMetric(iteration, "WebGPU-Total");
+
+        for (const [suiteName, results] of Object.entries(iterationResults)) {
+            if (results.total > 0) {
+                const suite = this._suites.find(s => s.name === suiteName);
+                if (suite?.tags?.includes("wasm")) {
+                    iterationWasmTotal.add(results.total);
+                } else if (suite?.tags?.includes("webgpu")) {
+                    iterationWebgpuTotal.add(results.total);
+                }
+            }
         }
-        iterationTotal.computeAggregatedMetrics();
-        if (!isNaN(iterationTotal.geomean) && iterationTotal.geomean > 0) {
-            geomean.add(iterationTotal.geomean);
-            getMetric("Score").add(geomeanToScore(iterationTotal.geomean));
+
+        iterationWasmTotal.computeAggregatedMetrics();
+        iterationWebgpuTotal.computeAggregatedMetrics();
+
+        if (!isNaN(iterationWasmTotal.geomean) && iterationWasmTotal.geomean > 0) {
+            wasmGeomean.add(iterationWasmTotal.geomean);
+            getMetric("WASM-Score", "score").add(geomeanToScore(iterationWasmTotal.geomean));
+        }
+        if (!isNaN(iterationWebgpuTotal.geomean) && iterationWebgpuTotal.geomean > 0) {
+            webgpuGeomean.add(iterationWebgpuTotal.geomean);
+            getMetric("WebGPU-Score", "score").add(geomeanToScore(iterationWebgpuTotal.geomean));
         }
 
         if (params.measurePrepare) {

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -218,7 +218,7 @@ class PageElement {
     }
 }
 
-function geomeanToScore(geomean) {
+export function geomeanToScore(geomean) {
     return 10000 / geomean;
 }
 
@@ -474,11 +474,21 @@ export class BenchmarkRunner {
     async _finalize(iteration) {
         this._appendIterationMetrics(iteration);
         if (this._client?.didRunSuites) {
-            const iterationWasmMetric = this._metrics[`Iteration-${iteration}-WASM-Total`];
+            const iterationWasmMetric = this._metrics[`Iteration-${iteration}-Wasm-Total`];
             const iterationWebgpuMetric = this._metrics[`Iteration-${iteration}-WebGPU-Total`];
 
-            const wasmGeomean = !isNaN(iterationWasmMetric?.geomean) ? iterationWasmMetric.geomean : 0;
-            const webgpuGeomean = !isNaN(iterationWebgpuMetric?.geomean) ? iterationWebgpuMetric.geomean : 0;
+            const hasWasm = this._suites.some(s => s.enabled && s.tags?.includes("wasm"));
+            const hasWebgpu = this._suites.some(s => s.enabled && s.tags?.includes("webgpu"));
+
+            if (hasWasm && isNaN(iterationWasmMetric?.geomean)) {
+                throw new Error(`Iteration ${iteration}: Wasm was enabled but produced NaN geomean.`);
+            }
+            if (hasWebgpu && isNaN(iterationWebgpuMetric?.geomean)) {
+                throw new Error(`Iteration ${iteration}: WebGPU was enabled but produced NaN geomean.`);
+            }
+
+            const wasmGeomean = hasWasm ? iterationWasmMetric.geomean : 0;
+            const webgpuGeomean = hasWebgpu ? iterationWebgpuMetric.geomean : 0;
 
             this._measuredValues.wasmGeomean = wasmGeomean;
             this._measuredValues.wasmScore = geomeanToScore(wasmGeomean);
@@ -519,20 +529,20 @@ export class BenchmarkRunner {
             // Prepare all iteration metrics so they are listed at the end of
             // of the _metrics object.
             for (let i = 0; i < this._iterationCount; i++) {
-                iterationMetric(i, "WASM-Total").description = `WASM test totals for iteration ${i}`;
+                iterationMetric(i, "Wasm-Total").description = `Wasm test totals for iteration ${i}`;
                 iterationMetric(i, "WebGPU-Total").description = `WebGPU test totals for iteration ${i}`;
             }
-            getMetric("WASM-Geomean", "ms").description = "Geomean of WASM test totals";
-            getMetric("WASM-Score", "score").description = "Scaled inverse of the WASM Geomean";
+            getMetric("Wasm-Geomean", "ms").description = "Geomean of Wasm test totals";
+            getMetric("Wasm-Score", "score").description = "Scaled inverse of the Wasm Geomean";
             getMetric("WebGPU-Geomean", "ms").description = "Geomean of WebGPU test totals";
             getMetric("WebGPU-Score", "score").description = "Scaled inverse of the WebGPU Geomean";
             if (params.measurePrepare)
                 getMetric("Prepare", "ms").description = "Geomean of workload prepare times";
         }
 
-        const wasmGeomean = getMetric("WASM-Geomean");
+        const wasmGeomean = getMetric("Wasm-Geomean");
         const webgpuGeomean = getMetric("WebGPU-Geomean");
-        const iterationWasmTotal = iterationMetric(iteration, "WASM-Total");
+        const iterationWasmTotal = iterationMetric(iteration, "Wasm-Total");
         const iterationWebgpuTotal = iterationMetric(iteration, "WebGPU-Total");
 
         for (const [suiteName, results] of Object.entries(iterationResults)) {
@@ -542,6 +552,8 @@ export class BenchmarkRunner {
                     iterationWasmTotal.add(results.total);
                 } else if (suite?.tags?.includes("webgpu")) {
                     iterationWebgpuTotal.add(results.total);
+                } else {
+                    throw new Error(`Suite ${suiteName} has neither "wasm" nor "webgpu" tag.`);
                 }
             }
         }
@@ -551,7 +563,7 @@ export class BenchmarkRunner {
 
         if (!isNaN(iterationWasmTotal.geomean) && iterationWasmTotal.geomean > 0) {
             wasmGeomean.add(iterationWasmTotal.geomean);
-            getMetric("WASM-Score", "score").add(geomeanToScore(iterationWasmTotal.geomean));
+            getMetric("Wasm-Score", "score").add(geomeanToScore(iterationWasmTotal.geomean));
         }
         if (!isNaN(iterationWebgpuTotal.geomean) && iterationWebgpuTotal.geomean > 0) {
             webgpuGeomean.add(iterationWebgpuTotal.geomean);

--- a/resources/main.css
+++ b/resources/main.css
@@ -437,31 +437,45 @@ iframe.test-runner {
     background: var(--running-background);
 }
 
-section#summary > #result-number,
-section#summary > #confidence-number {
+.scores-container {
+    display: flex;
+    justify-content: center;
+    gap: 80px;
+    margin: 40px 0;
     font-family: "Futura-CondensedMedium", Futura, "Helvetica Neue", Helvetica, Verdana, sans-serif;
 }
 
-section#summary > #result-number {
-    text-align: center;
-    font-size: 145px;
-    line-height: 145px;
+.score-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-width: 200px;
 }
 
-section#summary > #confidence-number {
-    text-align: center;
+.score-box h2 {
+    font-size: 20px;
+    margin-bottom: 15px;
+    color: var(--inactive-color);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.score-box .score-value {
     font-size: 36px;
     line-height: 36px;
-    color: var(--inactive-color);
+    font-weight: bold;
+    color: var(--highlight);
 }
 
-section#summary.invalid h1,
-section#summary.invalid .gauge,
-section#summary.invalid hr {
-    opacity: 0.2;
+.score-box .score-confidence {
+    font-size: 16px;
+    line-height: 20px;
+    color: var(--inactive-color);
+    margin-top: 5px;
 }
-section#summary.invalid #result-number {
-    color: var(--highlight);
+
+section#summary.invalid .scores-container {
+    opacity: 0.2;
 }
 section#summary.invalid .buttons {
     display: none;
@@ -732,36 +746,7 @@ section#about .note {
     grid-area: footer;
 }
 
-.gauge {
-    position: relative;
-    width: 738px;
-    height: 78px;
-    background-image: -webkit-image-set(url("gauge@2x.png") 2x, url("gauge.png") 1x);
-    background-image: image-set(url("gauge@2x.png") 2x, url("gauge.png") 1x);
-    background-size: 100% 100%;
-    background-repeat: no-repeat;
-    margin: 0 auto;
-}
 
-.gauge > .window {
-    position: absolute;
-    left: 0;
-    top: 33px;
-    bottom: 0;
-    right: 0;
-    overflow: hidden;
-}
-
-.gauge > .window > .needle {
-    position: absolute;
-    left: 363px;
-    bottom: -88px;
-    width: 4px;
-    height: 400px;
-    background-color: rgb(247, 148, 29);
-    transform: rotate(-70deg);
-    transform-origin: 2px 400px;
-}
 
 .all-metric-results .submetrics {
     display: none;
@@ -959,3 +944,5 @@ section#about .note {
     color: #fff;
     stroke: #fff;
 }
+
+

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -157,9 +157,11 @@ class MainBenchmarkClient {
         this._hasResults = true;
         this._metrics = metrics;
 
-        const scoreResults = this._computeResults(this._measuredValuesList, "score");
-        if (scoreResults.isValid)
-            this._populateValidScore(scoreResults);
+        const wasmScoreResults = this._computeResults(this._measuredValuesList, "wasmScore", "score");
+        const webgpuScoreResults = this._computeResults(this._measuredValuesList, "webgpuScore", "score");
+
+        if (wasmScoreResults.isValid || webgpuScoreResults.isValid)
+            this._populateValidScores(wasmScoreResults, webgpuScoreResults);
         else
             this._populateInvalidScore();
 
@@ -178,28 +180,37 @@ class MainBenchmarkClient {
         throw error;
     }
 
-    _populateValidScore(scoreResults) {
+    _populateValidScores(wasmScoreResults, webgpuScoreResults) {
         document.getElementById("summary").className = "valid";
 
-        this._updateGaugeNeedle(scoreResults.mean);
-        document.getElementById("result-number").textContent = scoreResults.formattedMean;
-        if (scoreResults.formattedDelta)
-            document.getElementById("confidence-number").textContent = `\u00b1 ${scoreResults.formattedDelta}`;
+        if (wasmScoreResults.isValid) {
+            document.getElementById("wasm-result-number").textContent = wasmScoreResults.formattedMean;
+            if (wasmScoreResults.formattedDelta)
+                document.getElementById("wasm-confidence-number").textContent = `\u00b1 ${wasmScoreResults.formattedDelta}`;
+        } else {
+            document.getElementById("wasm-result-number").textContent = "N/A";
+            document.getElementById("wasm-confidence-number").textContent = "";
+        }
+
+        if (webgpuScoreResults.isValid) {
+            document.getElementById("webgpu-result-number").textContent = webgpuScoreResults.formattedMean;
+            if (webgpuScoreResults.formattedDelta)
+                document.getElementById("webgpu-confidence-number").textContent = `\u00b1 ${webgpuScoreResults.formattedDelta}`;
+        } else {
+            document.getElementById("webgpu-result-number").textContent = "N/A";
+            document.getElementById("webgpu-confidence-number").textContent = "";
+        }
     }
 
     _populateInvalidScore() {
         document.getElementById("summary").className = "invalid";
-        document.getElementById("result-number").textContent = "Error";
-        document.getElementById("confidence-number").textContent = "";
+        document.getElementById("wasm-result-number").textContent = "Error";
+        document.getElementById("wasm-confidence-number").textContent = "";
+        document.getElementById("webgpu-result-number").textContent = "Error";
+        document.getElementById("webgpu-confidence-number").textContent = "";
     }
 
-    _computeResults(measuredValuesList, displayUnit) {
-        function valueForUnit(measuredValues) {
-            if (displayUnit === "ms")
-                return measuredValues.geomean;
-            return measuredValues.score;
-        }
-
+    _computeResults(measuredValuesList, valueKey, displayUnit) {
         function sigFigFromPercentDelta(percentDelta) {
             return Math.ceil(-Math.log(percentDelta) / Math.log(10)) + 3;
         }
@@ -209,7 +220,7 @@ class MainBenchmarkClient {
             return number.toPrecision(Math.max(nonDecimalDigitCount, Math.min(6, sigFig)));
         }
 
-        const values = measuredValuesList.map(valueForUnit);
+        const values = measuredValuesList.map(v => v[valueKey]);
         const sum = values.reduce((a, b) => a + b, 0);
         const arithmeticMean = sum / values.length;
         let meanSigFig = 4;
@@ -248,17 +259,6 @@ class MainBenchmarkClient {
         table.appendChild(row);
     }
 
-    _updateGaugeNeedle(score) {
-        const needleAngle = Math.max(0, Math.min(score, 140)) - 70;
-        const needleRotationValue = `rotate(${needleAngle}deg)`;
-
-        const gaugeNeedleElement = document.querySelector("#summary > .gauge .needle");
-        gaugeNeedleElement.style.setProperty("-webkit-transform", needleRotationValue);
-        gaugeNeedleElement.style.setProperty("-moz-transform", needleRotationValue);
-        gaugeNeedleElement.style.setProperty("-ms-transform", needleRotationValue);
-        gaugeNeedleElement.style.setProperty("transform", needleRotationValue);
-    }
-
     _populateDetailedResults(metrics) {
         this._populateNonStandardParams();
 
@@ -283,8 +283,12 @@ class MainBenchmarkClient {
         const trackHeight = 24;
         document.documentElement.style.setProperty("--metrics-line-height", `${trackHeight}px`);
         const plotWidth = (params.viewport.width - 120) / 2;
-        const aggregateMetrics = [metrics.Geomean];
-        if (params.measurePrepare)
+        const aggregateMetrics = [];
+        if (metrics["WASM-Score"])
+            aggregateMetrics.push(metrics["WASM-Score"]);
+        if (metrics["WebGPU-Score"])
+            aggregateMetrics.push(metrics["WebGPU-Score"]);
+        if (params.measurePrepare && metrics.Prepare)
             aggregateMetrics.push(metrics.Prepare);
         document.getElementById("aggregate-chart").innerHTML = renderMetricView({
             metrics: aggregateMetrics,

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -284,8 +284,8 @@ class MainBenchmarkClient {
         document.documentElement.style.setProperty("--metrics-line-height", `${trackHeight}px`);
         const plotWidth = (params.viewport.width - 120) / 2;
         const aggregateMetrics = [];
-        if (metrics["WASM-Score"]?.values.length > 0)
-            aggregateMetrics.push(metrics["WASM-Score"]);
+        if (metrics["Wasm-Score"]?.values.length > 0)
+            aggregateMetrics.push(metrics["Wasm-Score"]);
         if (metrics["WebGPU-Score"]?.values.length > 0)
             aggregateMetrics.push(metrics["WebGPU-Score"]);
         if (params.measurePrepare && metrics.Prepare?.values.length > 0)

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -284,11 +284,11 @@ class MainBenchmarkClient {
         document.documentElement.style.setProperty("--metrics-line-height", `${trackHeight}px`);
         const plotWidth = (params.viewport.width - 120) / 2;
         const aggregateMetrics = [];
-        if (metrics["WASM-Score"])
+        if (metrics["WASM-Score"]?.values.length > 0)
             aggregateMetrics.push(metrics["WASM-Score"]);
-        if (metrics["WebGPU-Score"])
+        if (metrics["WebGPU-Score"]?.values.length > 0)
             aggregateMetrics.push(metrics["WebGPU-Score"]);
-        if (params.measurePrepare && metrics.Prepare)
+        if (params.measurePrepare && metrics.Prepare?.values.length > 0)
             aggregateMetrics.push(metrics.Prepare);
         document.getElementById("aggregate-chart").innerHTML = renderMetricView({
             metrics: aggregateMetrics,

--- a/tests/run-end2end.mjs
+++ b/tests/run-end2end.mjs
@@ -77,8 +77,8 @@ async function testPage(url) {
 function validateMetrics(metrics) {
     for (const [name, metric] of Object.entries(metrics))
         validateMetric(name, metric);
-    assert((metrics["WASM-Geomean"]?.mean > 0) || (metrics["WebGPU-Geomean"]?.mean > 0));
-    assert((metrics["WASM-Score"]?.mean > 0) || (metrics["WebGPU-Score"]?.mean > 0));
+    assert((metrics["Wasm-Geomean"]?.mean > 0) || (metrics["WebGPU-Geomean"]?.mean > 0));
+    assert((metrics["Wasm-Score"]?.mean > 0) || (metrics["WebGPU-Score"]?.mean > 0));
 }
 
 function validateMetric(name, metric) {
@@ -100,9 +100,9 @@ async function testIterations() {
             assert(!(suite.name in metrics));
         }
     });
-    if (metrics["WASM-Geomean"]?.mean > 0) {
-        assert(metrics["WASM-Geomean"].values.length === iterationCount);
-        assert(metrics["WASM-Score"].values.length === iterationCount);
+    if (metrics["Wasm-Geomean"]?.mean > 0) {
+        assert(metrics["Wasm-Geomean"].values.length === iterationCount);
+        assert(metrics["Wasm-Score"].values.length === iterationCount);
     }
     if (metrics["WebGPU-Geomean"]?.mean > 0) {
         assert(metrics["WebGPU-Geomean"].values.length === iterationCount);
@@ -146,9 +146,9 @@ async function testAll() {
         const metric = metrics[suite.name];
         assert(metric.values.length === 1);
     });
-    if (metrics["WASM-Geomean"]?.mean > 0) {
-        assert(metrics["WASM-Geomean"].values.length === 1);
-        assert(metrics["WASM-Score"].values.length === 1);
+    if (metrics["Wasm-Geomean"]?.mean > 0) {
+        assert(metrics["Wasm-Geomean"].values.length === 1);
+        assert(metrics["Wasm-Score"].values.length === 1);
     }
     if (metrics["WebGPU-Geomean"]?.mean > 0) {
         assert(metrics["WebGPU-Geomean"].values.length === 1);

--- a/tests/run-end2end.mjs
+++ b/tests/run-end2end.mjs
@@ -77,8 +77,8 @@ async function testPage(url) {
 function validateMetrics(metrics) {
     for (const [name, metric] of Object.entries(metrics))
         validateMetric(name, metric);
-    assert(metrics.Geomean.mean > 0);
-    assert(metrics.Score.mean > 0);
+    assert((metrics["WASM-Geomean"]?.mean > 0) || (metrics["WebGPU-Geomean"]?.mean > 0));
+    assert((metrics["WASM-Score"]?.mean > 0) || (metrics["WebGPU-Score"]?.mean > 0));
 }
 
 function validateMetric(name, metric) {
@@ -100,8 +100,14 @@ async function testIterations() {
             assert(!(suite.name in metrics));
         }
     });
-    assert(metrics.Geomean.values.length === iterationCount);
-    assert(metrics.Score.values.length === iterationCount);
+    if (metrics["WASM-Geomean"]?.mean > 0) {
+        assert(metrics["WASM-Geomean"].values.length === iterationCount);
+        assert(metrics["WASM-Score"].values.length === iterationCount);
+    }
+    if (metrics["WebGPU-Geomean"]?.mean > 0) {
+        assert(metrics["WebGPU-Geomean"].values.length === iterationCount);
+        assert(metrics["WebGPU-Score"].values.length === iterationCount);
+    }
 }
 
 async function testSubIterations() {
@@ -140,8 +146,14 @@ async function testAll() {
         const metric = metrics[suite.name];
         assert(metric.values.length === 1);
     });
-    assert(metrics.Geomean.values.length === 1);
-    assert(metrics.Score.values.length === 1);
+    if (metrics["WASM-Geomean"]?.mean > 0) {
+        assert(metrics["WASM-Geomean"].values.length === 1);
+        assert(metrics["WASM-Score"].values.length === 1);
+    }
+    if (metrics["WebGPU-Geomean"]?.mean > 0) {
+        assert(metrics["WebGPU-Geomean"].values.length === 1);
+        assert(metrics["WebGPU-Score"].values.length === 1);
+    }
 }
 
 async function testDeveloperMode() {

--- a/tests/unittests/benchmark-runner.mjs
+++ b/tests/unittests/benchmark-runner.mjs
@@ -15,12 +15,14 @@ const SUITES_FIXTURE = [
         name: "Suite 1",
         async prepare(page) {},
         enabled: true,
+        tags: ["webgpu"],
         steps: [STEP_FIXTURE("Test 1"), STEP_FIXTURE("Test 2"), STEP_FIXTURE("Test 3")],
     },
     {
         name: "Suite 2",
         async prepare(page) {},
         enabled: true,
+        tags: ["wasm"],
         steps: [STEP_FIXTURE("Test 1")],
     },
 ];
@@ -239,16 +241,15 @@ describe("BenchmarkRunner", () => {
                     const asyncTime = asyncEnd - syncEnd;
 
                     const total = syncTime + asyncTime;
-                    const mean = total / suite.steps.length;
                     const geomean = Math.pow(total, 1 / suite.steps.length);
-                    const score = 1000 / geomean;
+                    const score = 100000 / geomean;
 
-                    const { total: measuredTotal, mean: measuredMean, geomean: measuredGeomean, score: measuredScore } = runner._measuredValues;
+                    const { wasmGeomean, wasmScore, webgpuGeomean, webgpuScore } = runner._measuredValues;
 
-                    expect(measuredTotal).to.equal(total);
-                    expect(measuredMean).to.equal(mean);
-                    expect(measuredGeomean).to.equal(geomean);
-                    expect(measuredScore).to.equal(score);
+                    expect(wasmGeomean).to.equal(geomean);
+                    expect(wasmScore).to.equal(score);
+                    expect(webgpuGeomean).to.equal(0);
+                    expect(webgpuScore).to.equal(Infinity);
 
                     assert.calledWith(runner._client.didRunSuites, runner._measuredValues);
                 });

--- a/tests/unittests/benchmark-runner.mjs
+++ b/tests/unittests/benchmark-runner.mjs
@@ -242,7 +242,7 @@ describe("BenchmarkRunner", () => {
 
                     const total = syncTime + asyncTime;
                     const geomean = Math.pow(total, 1 / suite.steps.length);
-                    const score = 100000 / geomean;
+                    const score = 10000 / geomean;
 
                     const { wasmGeomean, wasmScore, webgpuGeomean, webgpuScore } = runner._measuredValues;
 

--- a/tests/unittests/benchmark-runner.mjs
+++ b/tests/unittests/benchmark-runner.mjs
@@ -1,4 +1,4 @@
-import { BenchmarkRunner } from "../../resources/benchmark-runner.mjs";
+import { BenchmarkRunner, geomeanToScore } from "../../resources/benchmark-runner.mjs";
 import { SuiteRunner } from "../../resources/suite-runner.mjs";
 import { StepRunner } from "../../resources/shared/step-runner.mjs";
 import { defaultParams } from "../../resources/shared/params.mjs";
@@ -216,7 +216,11 @@ describe("BenchmarkRunner", () => {
 
                 const params = { measurementMethod: "raf" };
 
+                let originalEnabledState;
                 before(async () => {
+                    originalEnabledState = SUITES_FIXTURE[0].enabled;
+                    SUITES_FIXTURE[0].enabled = false;
+
                     stub(runner, "_measuredValues").value({
                         steps: {},
                     });
@@ -236,13 +240,17 @@ describe("BenchmarkRunner", () => {
                     await runner._finalize();
                 });
 
+                after(() => {
+                    SUITES_FIXTURE[0].enabled = originalEnabledState;
+                });
+
                 it("should calculate measured test values correctly", () => {
                     const syncTime = syncEnd - syncStart;
                     const asyncTime = asyncEnd - syncEnd;
 
                     const total = syncTime + asyncTime;
                     const geomean = Math.pow(total, 1 / suite.steps.length);
-                    const score = 10000 / geomean;
+                    const score = geomeanToScore(geomean);
 
                     const { wasmGeomean, wasmScore, webgpuGeomean, webgpuScore } = runner._measuredValues;
 


### PR DESCRIPTION
This pull request updated the benchmark to tracking and displaying two independent performance metrics: WASM Score and WebGPU Score. Additionally, the score calculation scaling factor has been adjusted from `100,000 / geomean` to `10,000 / geomean` to produce more intuitive, readable score numbers across all workloads. The UI and test suites have also been updated to support these dual scores and ensure stable end-to-end reporting when running subset benchmarks.

Closes #170 