### PR TITLE
Fix ci build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,17 @@ jobs:
             - name: Install Node Packages
               run: npm ci
 
+            - name: Cache Models
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      resources/transformers-js/models
+                      resources/litert-js/models
+                      resources/experimental/models
+                  key: ${{ runner.os }}-models-${{ hashFiles('**/download-models.mjs') }}
+                  restore-keys: |
+                      ${{ runner.os }}-models-
+
             - name: Download Models and Build Benchmarks
               run: npm run build
 

--- a/about.html
+++ b/about.html
@@ -18,8 +18,8 @@
                     <div class="section-content">
                         <h2>Benchmark Version</h2>
                         <ul>
-                            <li>Version: <!-- package-version -->0.2.0 (2026-05-29)<!-- /package-version --></li>
-                            <li>Git commit: <!-- git-commit-link --><a href="https://github.com/GoogleChrome/webai-compute-benchmark/commit/63e9c80d7d2762b7baa89410a5ab497fd068fecb" target="_blank">63e9c80</a><!-- /git-commit-link --></li>
+                            <li>Version: <!-- package-version -->0.2.0 (2026-06-17)<!-- /package-version --></li>
+                            <li>Git commit: <!-- git-commit-link --><a href="https://github.com/GoogleChrome/webai-compute-benchmark/commit/498847f972c7bda84ab7dea6370b94db7365e190" target="_blank">498847f</a><!-- /git-commit-link --></li>
                         </ul>
                         <h2>Library Versions</h2>
                         <ul>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
                         Additionally, the first iteration of the benchmark <b>may take several minutes</b> to complete.
                     </p>
                     <p class="version-note">
-                        Version: <!-- package-version -->0.2.0 (2026-05-29)<!-- /package-version --> (commit: <!-- git-commit-link --><a href="https://github.com/GoogleChrome/webai-compute-benchmark/commit/63e9c80d7d2762b7baa89410a5ab497fd068fecb" target="_blank">63e9c80</a><!-- /git-commit-link -->)
+                        Version: <!-- package-version -->0.2.0 (2026-06-17)<!-- /package-version --> (commit: <!-- git-commit-link --><a href="https://github.com/GoogleChrome/webai-compute-benchmark/commit/498847f972c7bda84ab7dea6370b94db7365e190" target="_blank">498847f</a><!-- /git-commit-link -->)
                     </p>
                     <p id="screen-size-warning">
                         <strong>
@@ -89,7 +89,7 @@
                     <div class="version next">next</div>
                 </a>
                 <div class="section-grid">
-                    <h1 class="section-header">Detailed Results <!-- package-version -->0.2.0 (2026-05-29)<!-- /package-version --></h1>
+                    <h1 class="section-header">Detailed Results <!-- package-version -->0.2.0 (2026-06-17)<!-- /package-version --></h1>
                     <div class="section-content all-metric-results">
                         <div class="non-standard-params">
                             <h2>Non-standard Parameters</h2>

--- a/resources/experimental/src/download-models.mjs
+++ b/resources/experimental/src/download-models.mjs
@@ -1,8 +1,11 @@
 import { env, pipeline} from '@huggingface/transformers';
 import fs from 'fs';
+import path from 'path';
+import DownloadCache from '../../shared/download-cache.mjs';
 
 const MODEL_DIR = './models';
 env.localModelPath = MODEL_DIR;
+const CACHE_VERSION = 1;
 
 const MODELS_TO_DOWNLOAD = [
     { 
@@ -12,7 +15,22 @@ const MODELS_TO_DOWNLOAD = [
     },
 ];
 
+async function retry(fn, retries = 3, delay = 2000) {
+    for (let i = 0; i < retries; i++) {
+        try {
+            return await fn();
+        } catch (err) {
+            if (i === retries - 1) throw err;
+            console.warn(`Attempt ${i + 1} failed. Retrying in ${delay}ms...`, err.message);
+            await new Promise(resolve => setTimeout(resolve, delay));
+        }
+    }
+}
+
 async function downloadModels() {
+    const CACHE_FILE = path.join(MODEL_DIR, 'cache.json');
+    const cache = new DownloadCache(CACHE_FILE, CACHE_VERSION, process.argv.includes('--force'));
+
     if (!fs.existsSync(MODEL_DIR)) {
         console.log(`Creating directory: ${MODEL_DIR}`);
         fs.mkdirSync(MODEL_DIR, { recursive: true }); 
@@ -28,17 +46,24 @@ async function downloadModels() {
         for (const modelInfo of MODELS_TO_DOWNLOAD) {
             const { id: modelId, task: modelTask, dtype: modelDType } = modelInfo;
             
+            const cacheKey = `${modelId}-${modelTask}-${modelDType}`;
+            if (cache.has(cacheKey)) {
+                console.log(`Model ${modelId} (${modelTask}, dtype: ${modelDType}) already cached. Skipping.`);
+                continue;
+            }
+
             console.log(`Downloading files for ${modelId} (${modelTask}, dtype: ${modelDType})...`);
             
-            await pipeline(
+            await retry(() => pipeline(
                 modelTask, 
                 modelId, 
                 { 
                     cache_dir: env.localModelPath,
                     dtype: modelDType
-                });
+                }));
             
             console.log(`Successfully downloaded and cached ${modelId}`);
+            cache.put(cacheKey);
         }
 
     } catch (err) {

--- a/resources/experimental/src/download-models.mjs
+++ b/resources/experimental/src/download-models.mjs
@@ -2,6 +2,7 @@ import { env, pipeline} from '@huggingface/transformers';
 import fs from 'fs';
 import path from 'path';
 import DownloadCache from '../../shared/download-cache.mjs';
+import { retry } from '../../shared/download-utils.mjs';
 
 const MODEL_DIR = './models';
 env.localModelPath = MODEL_DIR;
@@ -15,17 +16,6 @@ const MODELS_TO_DOWNLOAD = [
     },
 ];
 
-async function retry(fn, retries = 3, delay = 2000) {
-    for (let i = 0; i < retries; i++) {
-        try {
-            return await fn();
-        } catch (err) {
-            if (i === retries - 1) throw err;
-            console.warn(`Attempt ${i + 1} failed. Retrying in ${delay}ms...`, err.message);
-            await new Promise(resolve => setTimeout(resolve, delay));
-        }
-    }
-}
 
 async function downloadModels() {
     const CACHE_FILE = path.join(MODEL_DIR, 'cache.json');

--- a/resources/litert-js/src/download-models.mjs
+++ b/resources/litert-js/src/download-models.mjs
@@ -26,6 +26,18 @@ const MODELS_TO_DOWNLOAD = [
     }
 ];
 
+async function retry(fn, retries = 3, delay = 2000) {
+    for (let i = 0; i < retries; i++) {
+        try {
+            return await fn();
+        } catch (err) {
+            if (i === retries - 1) throw err;
+            console.warn(`Attempt ${i + 1} failed. Retrying in ${delay}ms...`, err.message);
+            await new Promise(resolve => setTimeout(resolve, delay));
+        }
+    }
+}
+
 async function downloadModels() {
     const CACHE_FILE = path.join(MODEL_DIR, 'cache.json');
     const cache = new DownloadCache(CACHE_FILE, CACHE_VERSION, process.argv.includes('--force'));
@@ -53,17 +65,19 @@ async function downloadModels() {
         console.log(`URL: ${modelUrl}`);
 
         try {
-            const response = await fetch(modelUrl);
+            await retry(async () => {
+                const response = await fetch(modelUrl);
 
-            if (!response.ok) {
-                throw new Error(`Failed to fetch: ${response.statusText} (${response.status})`);
-            }
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch: ${response.statusText} (${response.status})`);
+                }
 
-            const fileStream = fs.createWriteStream(outputPath);
-            await new Promise((resolve, reject) => {
-                response.body.pipe(fileStream);
-                response.body.on('error', reject);
-                fileStream.on('finish', resolve);
+                const fileStream = fs.createWriteStream(outputPath);
+                await new Promise((resolve, reject) => {
+                    response.body.pipe(fileStream);
+                    response.body.on('error', reject);
+                    fileStream.on('finish', resolve);
+                });
             });
             
             console.log(`Successfully downloaded **${filename}** to **${outputPath}**`);
@@ -79,7 +93,7 @@ async function downloadModels() {
 
             cache.put(cacheKey);
         } catch (err) {
-            console.error(`Model download failed for ${repo}/${filename}:`, err.message);
+            console.error(`Model download failed for ${repo}/${filename} after retries:`, err.message);
         }
     }
     console.log('TFLite download process finished.');

--- a/resources/litert-js/src/download-models.mjs
+++ b/resources/litert-js/src/download-models.mjs
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import fetch from 'node-fetch';
 import DownloadCache from '../../shared/download-cache.mjs';
+import { retry } from '../../shared/download-utils.mjs';
 import AdmZip from 'adm-zip';
 
 // --- Configuration ---
@@ -26,17 +27,6 @@ const MODELS_TO_DOWNLOAD = [
     }
 ];
 
-async function retry(fn, retries = 3, delay = 2000) {
-    for (let i = 0; i < retries; i++) {
-        try {
-            return await fn();
-        } catch (err) {
-            if (i === retries - 1) throw err;
-            console.warn(`Attempt ${i + 1} failed. Retrying in ${delay}ms...`, err.message);
-            await new Promise(resolve => setTimeout(resolve, delay));
-        }
-    }
-}
 
 async function downloadModels() {
     const CACHE_FILE = path.join(MODEL_DIR, 'cache.json');

--- a/resources/shared/download-utils.mjs
+++ b/resources/shared/download-utils.mjs
@@ -1,0 +1,11 @@
+export async function retry(fn, retries = 3, delay = 2000) {
+    for (let i = 0; i < retries; i++) {
+        try {
+            return await fn();
+        } catch (err) {
+            if (i === retries - 1) throw err;
+            console.warn(`Attempt ${i + 1} failed. Retrying in ${delay}ms...`, err.message);
+            await new Promise(resolve => setTimeout(resolve, delay));
+        }
+    }
+}

--- a/resources/transformers-js/src/download-models.mjs
+++ b/resources/transformers-js/src/download-models.mjs
@@ -66,6 +66,18 @@ function getHuggingFaceUrl(repo, filename, branch = 'main') {
     return `https://huggingface.co/${repo}/resolve/${branch}/${filename}`;
 }
 
+async function retry(fn, retries = 3, delay = 2000) {
+    for (let i = 0; i < retries; i++) {
+        try {
+            return await fn();
+        } catch (err) {
+            if (i === retries - 1) throw err;
+            console.warn(`Attempt ${i + 1} failed. Retrying in ${delay}ms...`, err.message);
+            await new Promise(resolve => setTimeout(resolve, delay));
+        }
+    }
+}
+
 async function downloadModels() {
     const CACHE_FILE = path.join(MODEL_DIR, 'cache.json');
     const cache = new DownloadCache(CACHE_FILE, CACHE_VERSION, process.argv.includes('--force'));
@@ -93,13 +105,13 @@ async function downloadModels() {
 
             console.log(`Downloading files for ${modelId} (${modelTask}, dtype: ${modelDType})...`);
             
-            await pipeline(
+            await retry(() => pipeline(
                 modelTask, 
                 modelId, 
                 { 
                     cache_dir: env.localModelPath,
                     dtype: modelDType
-                });
+                }));
             
             console.log(`Successfully downloaded and cached ${modelId}`);
             cache.put(cacheKey);
@@ -116,10 +128,10 @@ async function downloadModels() {
             }
 
             console.log(`Downloading Xenova/mobileclip_s0 (${className}${modelInfo.dtype ? `, dtype: ${modelInfo.dtype}` : ''})...`);
-            await modelInfo.modelClass.from_pretrained("Xenova/mobileclip_s0", {
+            await retry(() => modelInfo.modelClass.from_pretrained("Xenova/mobileclip_s0", {
                 cache_dir: env.localModelPath,
                 dtype: modelInfo.dtype
-            });
+            }));
 
             cache.put(cacheKey);
         }
@@ -129,12 +141,12 @@ async function downloadModels() {
         console.log(`Checking Xenova/sam-vit-base models...`);
         if (!cache.has('SAM-SamModel-fp32')) {
             console.log(`Downloading Xenova/sam-vit-base (SamModel, fp32)...`);
-            await SamModel.from_pretrained("Xenova/sam-vit-base", { cache_dir: env.localModelPath, dtype: 'fp32' });
+            await retry(() => SamModel.from_pretrained("Xenova/sam-vit-base", { cache_dir: env.localModelPath, dtype: 'fp32' }));
             cache.put('SAM-SamModel-fp32');
         }
         if (!cache.has('SAM-SamProcessor-default')) {
             console.log(`Downloading Xenova/sam-vit-base (SamProcessor)...`);
-            await SamProcessor.from_pretrained("Xenova/sam-vit-base", { cache_dir: env.localModelPath });
+            await retry(() => SamProcessor.from_pretrained("Xenova/sam-vit-base", { cache_dir: env.localModelPath }));
             cache.put('SAM-SamProcessor-default');
         }
         console.log(`Successfully checked Xenova/sam-vit-base`);
@@ -168,20 +180,22 @@ async function downloadModels() {
 
             console.log(`  Downloading ${filename}...`);
             try {
-                const response = await fetch(modelUrl);
-                if (!response.ok) {
-                    throw new Error(`Failed to fetch ${filename}: ${response.statusText}`);
-                }
-                const fileStream = fs.createWriteStream(outputPath);
-                await new Promise((resolve, reject) => {
-                    response.body.pipe(fileStream);
-                    response.body.on('error', reject);
-                    fileStream.on('finish', resolve);
+                await retry(async () => {
+                    const response = await fetch(modelUrl);
+                    if (!response.ok) {
+                        throw new Error(`Failed to fetch ${filename}: ${response.statusText}`);
+                    }
+                    const fileStream = fs.createWriteStream(outputPath);
+                    await new Promise((resolve, reject) => {
+                        response.body.pipe(fileStream);
+                        response.body.on('error', reject);
+                        fileStream.on('finish', resolve);
+                    });
                 });
 
                 cache.put(cacheKey);
             } catch (err) {
-                console.error(`  Failed to download ${filename}:`, err.message);
+                console.error(`  Failed to download ${filename} after retries:`, err.message);
             }
         }
         console.log(`Successfully checked all files for ${KOKORO_REPO}`);

--- a/resources/transformers-js/src/download-models.mjs
+++ b/resources/transformers-js/src/download-models.mjs
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import fetch from 'node-fetch';
 import DownloadCache from '../../shared/download-cache.mjs';
+import { retry } from '../../shared/download-utils.mjs';
 
 const MODEL_DIR = './models';
 env.localModelPath = MODEL_DIR;
@@ -64,18 +65,6 @@ function getHuggingFaceUrl(repo, filename, branch = 'main') {
         return `https://huggingface.co/${repo}/resolve/${branch}/onnx/${filename}`;
     }
     return `https://huggingface.co/${repo}/resolve/${branch}/${filename}`;
-}
-
-async function retry(fn, retries = 3, delay = 2000) {
-    for (let i = 0; i < retries; i++) {
-        try {
-            return await fn();
-        } catch (err) {
-            if (i === retries - 1) throw err;
-            console.warn(`Attempt ${i + 1} failed. Retrying in ${delay}ms...`, err.message);
-            await new Promise(resolve => setTimeout(resolve, delay));
-        }
-    }
 }
 
 async function downloadModels() {

--- a/script/helper.mjs
+++ b/script/helper.mjs
@@ -112,7 +112,8 @@ export async function sh(args, options={}) {
   try {
     return await spawnCaptureStdout(binary, args.slice(1), options);
   } catch(e) {
-    logError(e.stdoutString);
+    if (e.stdout) logError("Stdout:\n" + e.stdout);
+    if (e.stderr) logError("Stderr:\n" + e.stderr);
     throw e;
   } finally {
     if (GITHUB_ACTIONS_OUTPUT)
@@ -121,26 +122,36 @@ export async function sh(args, options={}) {
 }
 
 const SPAWN_OPTIONS =  Object.freeze({ 
-  stdio: ["inherit", "pipe", "inherit"]
+  stdio: ["inherit", "pipe", "pipe"]
 });
 
 async function spawnCaptureStdout(binary, args, options={}) {
   options = Object.assign(options, SPAWN_OPTIONS);
   const childProcess = spawn(binary, args, options);
   childProcess.stdout.pipe(process.stdout);
+  if (childProcess.stderr) {
+    childProcess.stderr.pipe(process.stderr);
+  }
   return new Promise((resolve, reject) => {
     childProcess.stdoutString = "";
+    childProcess.stderrString = "";
     childProcess.stdio[1].on("data", (data) => {
       childProcess.stdoutString += data.toString();
     });
+    if (childProcess.stdio[2]) {
+      childProcess.stdio[2].on("data", (data) => {
+        childProcess.stderrString += data.toString();
+      });
+    }
     childProcess.on("close", (code) => {
       if (code === 0) {
         resolve(childProcess);
       } else {
         // Reject the Promise with an Error on failure
-        const error = new Error(`Command failed with exit code ${code}: ${binary} ${args.join(" ")}`);
+        const error = new Error(`Command failed with exit code ${code}: ${binary} ${args.join(" ")}\nStderr:\n${childProcess.stderrString}`);
         error.process = childProcess;
         error.stdout = childProcess.stdoutString;
+        error.stderr = childProcess.stderrString;
         error.exitCode = code;
         reject(error);
       }


### PR DESCRIPTION
This PR improves CI build stability by 
1) Implementing retry logic (3 attempts with a 2-second delay) for model download,
2) Configuring GitHub Actions to cache model directories to speed up builds,
3) Reporting more clear failure error to provide clearer logs in CI.