### PR TITLE
Safe Model Caching and Gemma Protection

### DIFF
--- a/resources/experimental/src/download-models.mjs
+++ b/resources/experimental/src/download-models.mjs
@@ -19,7 +19,7 @@ const MODELS_TO_DOWNLOAD = [
 
 async function downloadModels() {
     const CACHE_FILE = path.join(MODEL_DIR, 'cache.json');
-    const cache = new DownloadCache(CACHE_FILE, CACHE_VERSION, process.argv.includes('--force'));
+    const cache = new DownloadCache(CACHE_FILE, CACHE_VERSION, process.argv.includes('--force'), ['gemma']);
 
     if (!fs.existsSync(MODEL_DIR)) {
         console.log(`Creating directory: ${MODEL_DIR}`);

--- a/resources/shared/download-cache.mjs
+++ b/resources/shared/download-cache.mjs
@@ -4,7 +4,7 @@ import path from 'path';
 export default class DownloadCache {
     cached = {};
 
-    constructor(filename, version, force) {
+    constructor(filename, version, force, excludes = []) {
         this.filename = filename;
         if (force) {
             return;
@@ -13,8 +13,23 @@ export default class DownloadCache {
             try {
                 const cacheData = JSON.parse(fs.readFileSync(filename, 'utf8'));
                 if (cacheData.version !== version) {
-                    console.log(`Cache version mismatch (found: ${cacheData.version}, expected: ${version}). Wiping models directory...`);
-                    fs.rmSync(path.dirname(filename), { recursive: true, force: true });
+                    console.log(`Cache version mismatch (found: ${cacheData.version}, expected: ${version}). Wiping models directory (excluding: ${excludes.join(', ')})...`);
+                    const dir = path.dirname(filename);
+                    if (excludes.length === 0) {
+                        fs.rmSync(dir, { recursive: true, force: true });
+                        fs.mkdirSync(dir, { recursive: true });
+                    } else {
+                        const files = fs.readdirSync(dir);
+                        for (const file of files) {
+                            if (excludes.includes(file) || file === path.basename(filename)) {
+                                continue;
+                            }
+                            fs.rmSync(path.join(dir, file), { recursive: true, force: true });
+                        }
+                    }
+                    this.cached = { version };
+                    // Write the fresh cache file to disk
+                    fs.writeFileSync(filename, JSON.stringify(this.cached, null, 2));
                 } else {
                     this.cached = cacheData;
                 }


### PR DESCRIPTION
This PR refines the model caching mechanism to prevent accidental deletion of unmanaged files (such as Gemma weights) during cache invalidation. It also fixes a bug where deleting a directory without exclusions caused build script failures due to missing parent folders.